### PR TITLE
Add localePath and getRouteBaseName to Nuxt's app

### DIFF
--- a/lib/templates/i18n.routing.plugin.js
+++ b/lib/templates/i18n.routing.plugin.js
@@ -1,46 +1,68 @@
 import './i18n.routing.middleware';
 import Vue from 'vue'
 
+
+function localePathFactory(i18nPath, routerPath) {
+  return function localePath(route, locale) {
+    if (!route) return
+    locale = locale || this[i18nPath].locale
+    if (!locale) return
+    // If route parameters is a string, consider it as the route's name
+    if (typeof route === 'string') {
+      route = { name: route }
+    }
+    // Build localized route options
+    const name = route.name + '-' + locale
+    const baseRoute = Object.assign({}, route, { name })
+    // Resolve localized router
+    const resolved = this[routerPath].resolve(baseRoute)
+    let { href } = resolved
+    // Cleanup href
+    href = (href.match(/^\/\/+$/)) ? '/' : href
+    return href
+  }
+}
+
+
+function getRouteBaseNameFactory( contextRoute ) {
+
+  const routeGetter  = contextRoute ? route => route || contextRoute : 
+  function (route) {
+    return route || this.$route
+  }
+
+  return function getRouteBaseName(route) {
+    route =  routeGetter.call(this, route)
+    if (!route.name) {
+      return null
+    }
+    const locales = <%= JSON.stringify(options.locales) %>
+  for (let i = locales.length - 1; i >= 0; i--) {
+      const regexp = new RegExp('-' + locales[i].code)
+      if (route.name.match(regexp)) {
+        return route.name.replace(regexp, '')
+      }
+    }
+  }
+}
+
 Vue.mixin({
   methods: {
-    localePath (route, locale) {
-      if (!route) return
-      locale = locale || this.$i18n.locale
-      if (!locale) return
-      // If route parameters is a string, consider it as the route's name
-      if (typeof route === 'string') {
-        route = { name: route }
-      }
-      // Build localized route options
-      const name = route.name + '-' + locale
-      const baseRoute = Object.assign({}, route, { name })
-      // Resolve localized route
-      const resolved = this.$router.resolve(baseRoute)
-      let { href } = resolved
-      // Cleanup href
-      href = (href.match(/^\/\/+$/)) ? '/' : href
-      return href
-    },
-    switchLocalePath (locale) {
+    localePath: localePathFactory('$i18n', '$router'),
+    switchLocalePath(locale) {
       const name = this.getRouteBaseName()
       if (!name) {
         return ''
       }
-      const baseRoute = Object.assign({}, this.$route, { name })
+      const baseRoute = Object.assign({}, this.$route , { name })
       return this.localePath(baseRoute, locale)
     },
-    getRouteBaseName (route) {
-      route = route || this.$route
-      if (!route.name) {
-        return null
-      }
-      const locales = <%= JSON.stringify(options.locales) %>
-      for (let i = locales.length - 1; i >= 0; i--) {
-        const regexp = new RegExp('-' + locales[i].code)
-        if (route.name.match(regexp)) {
-          return route.name.replace(regexp, '')
-        }
-      }
-    }
+    getRouteBaseName: getRouteBaseNameFactory()
   }
 })
+
+
+export default ({ app, route }) => {
+  app.localePath = localePathFactory('i18n', 'router')
+  app.getRouteBaseName = getRouteBaseNameFactory(route)
+}


### PR DESCRIPTION
Fix #24 . Vue Mixin through plugins are already too far in the lifecycle to be registered on Nuxt's app. The app is in fact, already created when the plugins are registered. 

This PR extracts `localePath` and `getRouteBaseName` into factories so as to configure where to get `$router, $route, $i18n` and registers these 2 methods both in the mixin and on app.

( I don't believe anyone will use `switchLocalePath` from app... )