### PR TITLE
Avoid server error without accept-language header

### DIFF
--- a/lib/templates/i18n.routing.middleware.js
+++ b/lib/templates/i18n.routing.middleware.js
@@ -23,7 +23,7 @@ middleware['i18n'] = function ({ app, req, res, route, params, redirect, error, 
     const cookies = req.headers && req.headers.cookies ?
       cookie.parse(req.headers.cookie) : {}
     // Redirect only if cookie not set yet
-    if (!cookies[cookieKey] || !useRedirectCookie) {
+    if (typeof req.headers['accept-language'] !== 'undefined' && (!cookies[cookieKey] || !useRedirectCookie)) {
       const browserLocale = req.headers['accept-language'].split(',')[0].toLocaleLowerCase().substring(0, 2)
       // Set cookie
       if (useRedirectCookie && res) {


### PR DESCRIPTION
When no Accept-Language header is provided, a 500 server error is currently thrown. This should be avoided

Related: https://github.com/nuxt/nuxt.js/issues/2034#issuecomment-342602183