### PR TITLE
support for deprecated vendor in nuxt-edge build

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -80,7 +80,8 @@ module.exports = function (moduleOptions) {
   })
   this.options.router.middleware.push('i18n')
 
-  this.options.build.vendor.push('vue-i18n')
+	// vendor is deprecated in nuxt-edge
+  if (this.options.build.vendor) this.options.build.vendor.push('vue-i18n')
 
   this.options.render.bundleRenderer.directives = this.options.render.bundleRenderer.directives || {}
   this.options.render.bundleRenderer.directives.t = i18nExtensions.directive


### PR DESCRIPTION
Plugin fails for latest `nuxt-edge` release, since vendor is deprecated.

This will allow both `nuxt` and `nuxt-edge` to build.

[You can read more here](https://medium.com/nuxt/nuxt-2-is-coming-oh-yeah-212c1a9e1a67#a688)