### PR TITLE
Fix problem for route names containing locale code

### DIFF
--- a/lib/templates/i18n.routing.plugin.js
+++ b/lib/templates/i18n.routing.plugin.js
@@ -44,7 +44,7 @@ function getRouteBaseNameFactory( contextRoute ) {
     }
     const locales = <%= JSON.stringify(options.locales) %>
   for (let i = locales.length - 1; i >= 0; i--) {
-      const regexp = new RegExp('-' + locales[i].code)
+      const regexp = new RegExp('-' + locales[i].code + '$')
       if (route.name.match(regexp)) {
         return route.name.replace(regexp, '')
       }


### PR DESCRIPTION
If you have nested routes such as `services-development-de` (german) and  `services-development-en` (english) `services-development-de` becomes `servicesvelopment-de`.

This commit fixes that problem!