### PR TITLE
Fix 'logger is not defined' error

### DIFF
--- a/src/templates/utils.js
+++ b/src/templates/utils.js
@@ -24,7 +24,7 @@ export async function loadLanguageAsync (i18n, locale) {
           i18n.loadedLanguages.push(locale)
           return messages
         } catch (error) {
-          logger.error(error)
+          console.error(error)
         }
         <% } %>
       } else {


### PR DESCRIPTION
@paulgv I thought I will just fix this one by myself this time. 😉