### PR TITLE
fix #82

### DIFF
--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -54,7 +54,7 @@ export const makeRoutes = (baseRoutes, {
     for (let i = 0, length1 = componentOptions.locales.length; i < length1; i++) {
       const locale = componentOptions.locales[i]
       let { name, path } = route
-      const localizedRoute = { ...route, children: [] }
+      const localizedRoute = { ...route }
 
       // Skip if locale not in module's configuration
       if (locales.indexOf(locale) === -1) {
@@ -64,6 +64,7 @@ export const makeRoutes = (baseRoutes, {
 
       // Generate localized children routes if any
       if (route.children) {
+        localizedRoute.children = []
         for (let i = 0, length1 = route.children.length; i < length1; i++) {
           localizedRoute.children = localizedRoute.children.concat(buildLocalizedRoutes(route.children[i], { locales: [locale] }, true))
         }


### PR DESCRIPTION
In nuxt 1.4.0, the method used during static generation test if children exist but not if children is empty.

By overwriting the children value to [] we automatically filter out the routes

see: https://github.com/nuxt/nuxt.js/blob/85b584693cd1e689406ad722b47735fa7d0faf26/lib/common/utils.js#L193