### PR TITLE
fix: support locales with names that match other locales (`en` and `en-us`)

### DIFF
--- a/src/plugins/routing.js
+++ b/src/plugins/routing.js
@@ -74,16 +74,12 @@ function getRouteBaseNameFactory (contextRoute) {
   }
 
   return function getRouteBaseName (route) {
-    const LOCALE_CODE_KEY = '<%= options.LOCALE_CODE_KEY %>'
-    const getLocaleCodes = <%= options.getLocaleCodes %>
     const routesNameSeparator = '<%= options.routesNameSeparator %>'
     route = routeGetter.call(this, route)
     if (!route.name) {
       return null
     }
-    const locales = getLocaleCodes(<%= JSON.stringify(options.locales) %>)
-    const regexp = new RegExp(routesNameSeparator + '(' + locales.join('|') + ')')
-    return route.name.replace(regexp, '')
+    return route.name.split(routesNameSeparator)[0]
   }
 }
 


### PR DESCRIPTION
Currently when an app supports multiple locales, which might match each others regex, the `getRouteBaseName` method returns the wrong result.

Example:

```
// locales = ['en', 'en-us']
// route.name = 'index___en-us'
// route.name.replace(regexp, '') will return 'index-us' and not 'index'
````