### PR TITLE
fix: making hreflang href full-qualified

### DIFF
--- a/src/plugins/seo.js
+++ b/src/plugins/seo.js
@@ -14,6 +14,7 @@ Vue.mixin({
     }
     const LOCALE_CODE_KEY = '<%= options.LOCALE_CODE_KEY %>'
     const LOCALE_ISO_KEY = '<%= options.LOCALE_ISO_KEY %>'
+    const BASE_URL = '<%= options.baseUrl %>'
 
     // Prepare html lang attribute
     const currentLocaleData = this.$i18n.locales.find(l => l[LOCALE_CODE_KEY] === this.$i18n.locale)
@@ -29,7 +30,7 @@ Vue.mixin({
           return {
             hid: 'alternate-hreflang-' + locale[LOCALE_ISO_KEY],
             rel: 'alternate',
-            href: this.switchLocalePath(locale.code),
+            href: BASE_URL + this.switchLocalePath(locale.code),
             hreflang: locale[LOCALE_ISO_KEY]
           }
         } else {


### PR DESCRIPTION
According to https://support.google.com/webmasters/answer/189077?hl=en href param should contain fully-qualified URL for the version of this page for the specified language/region:

> Alternate URLs must be fully-qualified, including the transport method (http/https), so:
 https://example.com/foo, not //example.com/foo or /foo

This also requires baseUrl parameter in the module config. E.g.:

`modules: [
        ['nuxt-i18n', {
            locales:               [
                {code: 'en', iso: 'en-US', file: 'en.js'},
                {code: 'fr', iso: 'fr-FR', file: 'fr.js'}
            ],
            defaultLocale:         'en',
            baseUrl:               'http://yoursite.com',
            strategy:              'prefix',
            detectBrowserLanguage: false,
            vuex:                  {
                moduleName: 'i18n',
                mutations: {
                    setLocale: 'SET_LANG',
                    setMessages: false
                }
            },
            vueI18n:               {
                fallbackLocale: 'en',
                messages:       {
                    en: en,
                    fr: fr
                }
            }
        }]
    ]`

