### PR TITLE
feat(strategy): add PREFIX_AND_DEFAULT strategy

### DIFF
--- a/docs/options-reference.md
+++ b/docs/options-reference.md
@@ -28,6 +28,7 @@ Here are all the options available when configuring the module and their default
   // Routes generation strategy, can be set to one of the following:
   // - 'prefix_except_default': add locale prefix for every locale except default
   // - 'prefix': add locale prefix for every locale
+  // - 'prefix_and_default': add locale prefix for every locale and default
   strategy: 'prefix_except_default',
 
   // Wether or not the translations should be lazy-loaded, if this is enabled,

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -50,7 +50,11 @@ Using this strategy, all of your routes will have a locale prefix added except f
 
 With this strategy, all routes will have a locale prefix.
 
-To configure the strategy, use the `strategy` option. Make sure you have a `defaultLocale` defined if using **prefix_except_default** strategy.
+### prefix_and_default
+
+Using this strategy, in addition to 'prefix' strategy, the route add `/` that use the default language
+
+To configure the strategy, use the `strategy` option. Make sure you have a `defaultLocale` defined if using **prefix_except_default**  or **prefix_and_default** strategy.
 
 
 ```js

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -14,7 +14,8 @@ export const LOCALE_FILE_KEY = 'file'
 // Options
 export const STRATEGIES = {
   PREFIX: 'prefix',
-  PREFIX_EXCEPT_DEFAULT: 'prefix_except_default'
+  PREFIX_EXCEPT_DEFAULT: 'prefix_except_default',
+  PREFIX_AND_DEFAULT: 'prefix_and_default'
 }
 export const COMPONENT_OPTIONS_KEY = 'nuxtI18n'
 export const DEFAULT_OPTIONS = {

--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -88,6 +88,11 @@ export const makeRoutes = (baseRoutes, {
         // Skip default locale if strategy is PREFIX_EXCEPT_DEFAULT
         !(locale === defaultLocale && strategy === STRATEGIES.PREFIX_EXCEPT_DEFAULT)
       )
+
+      if (locale === defaultLocale && strategy === STRATEGIES.PREFIX_AND_DEFAULT) {
+        routes.push({...localizedRoute, path})
+      }
+
       if (shouldAddPrefix) {
         path = `/${locale}${path}`
       }
@@ -95,6 +100,7 @@ export const makeRoutes = (baseRoutes, {
       localizedRoute.path = path
 
       routes.push(localizedRoute)
+
     }
 
     return routes


### PR DESCRIPTION
This strategy generates the following routing.

nuxt.config.js:
```javascript
{
  strategy: 'prefix_and_default',
  locales: [
    {
      code: 'ja',
      iso: 'ja',
      name: '日本語',
    },
    {
      code: 'en',
      iso: 'en-US',
      name: 'English',
    },
  ],
  defaultLocale: 'en',
}
```

routing:
```javascript
[
  {
    path: "/",
    component: _3237362a,
    name: "index___en"
  },
  {
    path: "/en",
    component: _3237362a,
    name: "index___en"
  },
  {
    path: "/ja",
    component: _3237362a,
    name: "index___ja"
  },
]
```

demo: https://relaxed-snyder-764840.netlify.com/