### PR TITLE
Get locale domains from store if present

### DIFF
--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -57,6 +57,12 @@ export default async ({ app, route, store, req }) => {
   app.i18n.beforeLanguageSwitch = <%= options.beforeLanguageSwitch %>
   app.i18n.onLanguageSwitched = <%= options.onLanguageSwitched %>
 
+  if (store && store.state.localeDomains) {
+    app.i18n.locales.forEach(locale => {
+      locale.domain = store.state.localeDomains[locale.code];
+    })
+  }
+
   let locale = app.i18n.defaultLocale || null
 
   if (app.i18n.differentDomains) {


### PR DESCRIPTION
## Problem

A website has a number of domains for each locale. The domains are set from environment variables and are different for the various environment (`dev`, `stage`, `prod`). The app is deployed via Docker to each environment. As the environment variables are accessed at build-time (nuxt.config.js) there is no way to change them without rebuilding the image, which undesirable as theoretically some differences may be introduced between images (e.g. in dependency resolution). It also adds additional overhead with managing those images for each environment.

## Solution

Keep the domains information in a separate file which can be included in nuxt.config.js and Vuex state from which nuxt-i18n plugin can read when it's initialised. This allows us to use domain environment variables at run-time as the domains map is stored in app's state.