### PR TITLE
feat: i18n.locale property changes when route changed

### DIFF
--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -56,6 +56,7 @@ export default async ({ app, route, store, req }) => {
   app.i18n.routesNameSeparator = '<%= options.routesNameSeparator %>'
   app.i18n.beforeLanguageSwitch = <%= options.beforeLanguageSwitch %>
   app.i18n.onLanguageSwitched = <%= options.onLanguageSwitched %>
+  app.i18n.onRouteChanged = (to, from) => {}
 
   if (store && store.state.localeDomains) {
     app.i18n.locales.forEach(locale => {
@@ -74,6 +75,7 @@ export default async ({ app, route, store, req }) => {
   }
 
   app.i18n.locale = locale
+  app.i18n.nextLocale = locale
 
   // Lazy-load translations
   if (lazy) {
@@ -84,5 +86,9 @@ export default async ({ app, route, store, req }) => {
   } else {
     // Sync Vuex
     syncVuex(locale, app.i18n.getLocaleMessage(locale))
+  }
+
+  if (!req) {
+    app.router.afterEach((to, from) => app.i18n.onRouteChanged(to, from))
   }
 }

--- a/src/templates/middleware.js
+++ b/src/templates/middleware.js
@@ -107,17 +107,25 @@ middleware['i18n'] = async ({ app, req, res, route, store, redirect, isHMR }) =>
 
   const oldLocale = app.i18n.locale
   app.i18n.beforeLanguageSwitch(oldLocale, locale)
+
+  let messages = ''
   // Lazy-loading enabled
   if (lazy) {
     const { loadLanguageAsync } = require('./utils')
-    const messages = await loadLanguageAsync(app.i18n, locale)
+    messages = await loadLanguageAsync(app.i18n, locale)
+  } else {
+    // Lazy-loading disabled
+    messages = app.i18n.getLocaleMessage(locale)
+  }
+
+  // NOTE: `app.i18n.locale` property changes when route changed.
+  // but, `fetch` and `asyncData` methods is called before it is changed.
+  // if you using this property use `app.i18n.nextLocale` instead.
+  app.i18n.nextLocale = locale
+
+  app.i18n.onRouteChanged = (to, from) => {
     app.i18n.locale = locale
     app.i18n.onLanguageSwitched(oldLocale, locale)
     syncVuex(locale, messages)
-  } else {
-    // Lazy-loading disabled
-    app.i18n.locale = locale
-    app.i18n.onLanguageSwitched(oldLocale, locale)
-    syncVuex(locale, app.i18n.getLocaleMessage(locale))
   }
 }


### PR DESCRIPTION
`i18n.locale` is reactive property. rerendered if it changed by using the `switchLocalePath` etc.

I think should that wait completed `fetch` or  `asyncData` methods.

I modified the changes timing of locale property

