### PR TITLE
fix: Include Types in NPM bundle (when published)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "src/plugins/*.*"
   ],
   "files": [
-    "src"
+    "src",
+    "types/index.d.ts"
   ],
   "jest": {
     "testEnvironment": "node",


### PR DESCRIPTION
I just updated to last version (5.4.0) and seen the `types` folder wasn't here in `node_modules`.

This PR is kind of a fix of my last merged PR about adding a TypeScript declaration file (#133).

I never published a NPM package so I was missing things around the package.json to make the types available in the bundle published.