### PR TITLE
Expose the head SEO function to be used in layouts

### DIFF
--- a/docs/seo.md
+++ b/docs/seo.md
@@ -65,3 +65,75 @@ export default {
 
 To override SEO metadata for any page, simply declare your own `head ()` method. Have a look at [src/plugins/seo.js](/src/plugins/seo.js) if you want to copy some of **nuxt-i18n**'s logic.
 
+## Improving performance
+
+The default method to inject SEO metadata, while convenient, comes at a performance costs.
+The `head` method is registered for every component in your app.
+This means each time a component is created, the SEO metadata is recomputed for every components.
+
+To improve performance you can use the `$nuxtI18nSeo` method in your layout instead.
+It will generate i18n SEO metadata for the current context.
+
+First you need to disable automatic SEO by setting `seo` to `false` in your configuration:
+
+```js
+// nuxt.config.js
+
+['nuxt-i18n', {
+  seo: false
+}]
+```
+
+Then in your app layout declare the [`head` hook](https://nuxtjs.org/api/pages-head#the-head-method) and use `$nuxtI18nSeo` inside to generate i18n SEO meta information:
+
+```js
+// layouts/default.vue
+
+export default {
+  head () {
+    return this.$nuxtI18nSeo()
+  }
+}
+```
+
+If you have more layouts, don't forget to add it there too.
+
+That's it!
+Now SEO metadata will only be computed for the layout instead of every component in your app.
+
+### Merging i18n SEO metadata with your own
+
+If you want to add your own meta in the layout you can easily merge the object returned by `$nuxtI18nSeo` with your own:
+
+```js
+// layouts/default.vue
+
+export default {
+  head () {
+    const i18nSeo = this.$nuxtI18nSeo()
+    return {
+      htmlAttrs: {
+        myAttribute: 'My Value',
+        ...i18nSeo.htmlAttrs
+      },
+      meta: [
+        {
+          hid: 'description',
+          name: 'description',
+          content: 'My Custom Description'
+        },
+        ...i18nSeo.meta
+      ],
+      link: [
+        {
+          hid: 'apple-touch-icon',
+          rel: 'apple-touch-icon',
+          sizes: '180x180',
+          href: '/apple-touch-icon.png'
+        },
+        ...i18nSeo.link
+     ]
+    }
+  }
+}
+```

--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -1,9 +1,10 @@
 import Vue from 'vue'
 import VueI18n from 'vue-i18n'
+import { nuxtI18nSeo } from './seo-head'
 
 Vue.use(VueI18n)
 
-export default async ({ app, route, store, req }) => {
+export default async ({ app, route, store, req }, inject) => {
   // Options
   const lazy = <%= options.lazy %>
   const vuex = <%= JSON.stringify(options.vuex) %>
@@ -56,7 +57,9 @@ export default async ({ app, route, store, req }) => {
   app.i18n.routesNameSeparator = '<%= options.routesNameSeparator %>'
   app.i18n.beforeLanguageSwitch = <%= options.beforeLanguageSwitch %>
   app.i18n.onLanguageSwitched = <%= options.onLanguageSwitched %>
-  app.i18n.nuxtI18n = { baseUrl: '<%= options.baseUrl %>' }
+
+  // Inject seo function
+  inject('nuxtI18nSeo', nuxtI18nSeo)
 
   if (store && store.state.localeDomains) {
     app.i18n.locales.forEach(locale => {

--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -59,7 +59,7 @@ export default async ({ app, route, store, req }, inject) => {
   app.i18n.onLanguageSwitched = <%= options.onLanguageSwitched %>
 
   // Inject seo function
-  inject('nuxtI18nSeo', nuxtI18nSeo)
+  Vue.prototype.$nuxtI18nSeo = nuxtI18nSeo
 
   if (store && store.state.localeDomains) {
     app.i18n.locales.forEach(locale => {

--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -56,6 +56,7 @@ export default async ({ app, route, store, req }) => {
   app.i18n.routesNameSeparator = '<%= options.routesNameSeparator %>'
   app.i18n.beforeLanguageSwitch = <%= options.beforeLanguageSwitch %>
   app.i18n.onLanguageSwitched = <%= options.onLanguageSwitched %>
+  app.i18n.nuxtI18n = { baseUrl: '<%= options.baseUrl %>' }
 
   if (store && store.state.localeDomains) {
     app.i18n.locales.forEach(locale => {

--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -4,7 +4,7 @@ import { nuxtI18nSeo } from './seo-head'
 
 Vue.use(VueI18n)
 
-export default async ({ app, route, store, req }, inject) => {
+export default async ({ app, route, store, req }) => {
   // Options
   const lazy = <%= options.lazy %>
   const vuex = <%= JSON.stringify(options.vuex) %>

--- a/src/plugins/seo.js
+++ b/src/plugins/seo.js
@@ -1,8 +1,6 @@
 import Vue from 'vue'
-import { nuxtI18nSeo } from '~/modules/nuxt-i18n/src/utils/seo'
+import { nuxtI18nSeo } from './seo-head'
 
 Vue.mixin({
-  head () {
-    return nuxtI18nSeo.bind(this)()
-  }
+  head: nuxtI18nSeo
 })

--- a/src/plugins/seo.js
+++ b/src/plugins/seo.js
@@ -1,74 +1,8 @@
 import Vue from 'vue'
+import { nuxtI18nSeo } from '~/modules/nuxt-i18n/src/utils/seo'
 
 Vue.mixin({
   head () {
-    const COMPONENT_OPTIONS_KEY = '<%= options.COMPONENT_OPTIONS_KEY %>'
-    if (
-      !this._hasMetaInfo ||
-      !this.$i18n ||
-      !this.$i18n.locales ||
-      this.$options[COMPONENT_OPTIONS_KEY] === false ||
-      (this.$options[COMPONENT_OPTIONS_KEY] && this.$options[COMPONENT_OPTIONS_KEY].seo === false)
-    ) {
-      return {};
-    }
-    const LOCALE_CODE_KEY = '<%= options.LOCALE_CODE_KEY %>'
-    const LOCALE_ISO_KEY = '<%= options.LOCALE_ISO_KEY %>'
-    const BASE_URL = '<%= options.baseUrl %>'
-
-    // Prepare html lang attribute
-    const currentLocaleData = this.$i18n.locales.find(l => l[LOCALE_CODE_KEY] === this.$i18n.locale)
-    const htmlAttrs = {}
-    if (currentLocaleData && currentLocaleData[LOCALE_ISO_KEY]) {
-      htmlAttrs.lang = currentLocaleData[LOCALE_ISO_KEY]
-    }
-
-    // hreflang tags
-    const link = this.$i18n.locales
-      .map(locale => {
-        if (locale[LOCALE_ISO_KEY]) {
-          return {
-            hid: 'alternate-hreflang-' + locale[LOCALE_ISO_KEY],
-            rel: 'alternate',
-            href: BASE_URL + this.switchLocalePath(locale.code),
-            hreflang: locale[LOCALE_ISO_KEY]
-          }
-        } else {
-          console.warn('[<%= options.MODULE_NAME %>] Locale ISO code is required to generate alternate link')
-          return null
-        }
-      })
-    .filter(item => !!item)
-
-    // og:locale meta
-    const meta = []
-    // og:locale - current
-    if (currentLocaleData && currentLocaleData[LOCALE_ISO_KEY]) {
-      meta.push({
-        hid: 'og:locale',
-        name: 'og:locale',
-        property: 'og:locale',
-        // Replace dash with underscore as defined in spec: language_TERRITORY
-        content: currentLocaleData[LOCALE_ISO_KEY].replace(/-/g, '_')
-      })
-    }
-    // og:locale - alternate
-    meta.push(
-      ...this.$i18n.locales
-        .filter(l => l[LOCALE_ISO_KEY] && l[LOCALE_ISO_KEY] !== currentLocaleData[LOCALE_ISO_KEY])
-        .map(locale => ({
-          hid: 'og:locale:alternate-' + locale[LOCALE_ISO_KEY],
-          name: 'og:locale:alternate',
-          property: 'og:locale:alternate',
-          content: locale[LOCALE_ISO_KEY].replace(/-/g, '_')
-        }))
-    );
-
-    return {
-      htmlAttrs,
-      link,
-      meta
-    }
+    return nuxtI18nSeo.bind(this)()
   }
 })
-

--- a/src/templates/seo-head.js
+++ b/src/templates/seo-head.js
@@ -1,8 +1,5 @@
-const LOCALE_CODE_KEY = 'code'
-const LOCALE_ISO_KEY = 'iso'
-const COMPONENT_OPTIONS_KEY = 'nuxtI18n'
-
 export const nuxtI18nSeo = function () {
+  const COMPONENT_OPTIONS_KEY = '<%= options.COMPONENT_OPTIONS_KEY %>'
   if (
     !this._hasMetaInfo ||
     !this.$i18n ||
@@ -12,8 +9,9 @@ export const nuxtI18nSeo = function () {
   ) {
     return {};
   }
-
-  const BASE_URL = this.$i18n.nuxtI18n.baseUrl
+  const LOCALE_CODE_KEY = '<%= options.LOCALE_CODE_KEY %>'
+  const LOCALE_ISO_KEY = '<%= options.LOCALE_ISO_KEY %>'
+  const BASE_URL = '<%= options.baseUrl %>'
 
   // Prepare html lang attribute
   const currentLocaleData = this.$i18n.locales.find(l => l[LOCALE_CODE_KEY] === this.$i18n.locale)
@@ -33,7 +31,7 @@ export const nuxtI18nSeo = function () {
           hreflang: locale[LOCALE_ISO_KEY]
         }
       } else {
-        console.warn('[nuxt-i18n] Locale ISO code is required to generate alternate link')
+        console.warn('[<%= options.MODULE_NAME %>] Locale ISO code is required to generate alternate link')
         return null
       }
     })

--- a/src/utils/seo.js
+++ b/src/utils/seo.js
@@ -1,0 +1,71 @@
+const LOCALE_CODE_KEY = 'code'
+const LOCALE_ISO_KEY = 'iso'
+const COMPONENT_OPTIONS_KEY = 'nuxtI18n'
+
+export const nuxtI18nSeo = function () {
+  if (
+    !this._hasMetaInfo ||
+    !this.$i18n ||
+    !this.$i18n.locales ||
+    this.$options[COMPONENT_OPTIONS_KEY] === false ||
+    (this.$options[COMPONENT_OPTIONS_KEY] && this.$options[COMPONENT_OPTIONS_KEY].seo === false)
+  ) {
+    return {};
+  }
+
+  const BASE_URL = this.$i18n.nuxtI18n.baseUrl
+
+  // Prepare html lang attribute
+  const currentLocaleData = this.$i18n.locales.find(l => l[LOCALE_CODE_KEY] === this.$i18n.locale)
+  const htmlAttrs = {}
+  if (currentLocaleData && currentLocaleData[LOCALE_ISO_KEY]) {
+    htmlAttrs.lang = currentLocaleData[LOCALE_ISO_KEY]
+  }
+
+  // hreflang tags
+  const link = this.$i18n.locales
+    .map(locale => {
+      if (locale[LOCALE_ISO_KEY]) {
+        return {
+          hid: 'alternate-hreflang-' + locale[LOCALE_ISO_KEY],
+          rel: 'alternate',
+          href: BASE_URL + this.switchLocalePath(locale.code),
+          hreflang: locale[LOCALE_ISO_KEY]
+        }
+      } else {
+        console.warn('[nuxt-i18n] Locale ISO code is required to generate alternate link')
+        return null
+      }
+    })
+    .filter(item => !!item)
+
+  // og:locale meta
+  const meta = []
+  // og:locale - current
+  if (currentLocaleData && currentLocaleData[LOCALE_ISO_KEY]) {
+    meta.push({
+      hid: 'og:locale',
+      name: 'og:locale',
+      property: 'og:locale',
+      // Replace dash with underscore as defined in spec: language_TERRITORY
+      content: currentLocaleData[LOCALE_ISO_KEY].replace(/-/g, '_')
+    })
+  }
+  // og:locale - alternate
+  meta.push(
+    ...this.$i18n.locales
+      .filter(l => l[LOCALE_ISO_KEY] && l[LOCALE_ISO_KEY] !== currentLocaleData[LOCALE_ISO_KEY])
+      .map(locale => ({
+        hid: 'og:locale:alternate-' + locale[LOCALE_ISO_KEY],
+        name: 'og:locale:alternate',
+        property: 'og:locale:alternate',
+        content: locale[LOCALE_ISO_KEY].replace(/-/g, '_')
+      }))
+  );
+
+  return {
+    htmlAttrs,
+    link,
+    meta
+  }
+}

--- a/test/fixtures/basic/__snapshots__/module.test.js.snap
+++ b/test/fixtures/basic/__snapshots__/module.test.js.snap
@@ -4,7 +4,7 @@ exports[`basic / contains EN text, link to /fr/ & link /about-us 1`] = `
 "<!doctype html>
 <html data-n-head-ssr lang=\\"en-US\\" data-n-head=\\"lang\\">
   <head>
-    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"en_US\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-fr-FR\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"fr_FR\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"4eb03412:0\\">
+    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"en_US\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-fr-FR\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"fr_FR\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"fd547dac:0\\">
 .nuxt-progress{position:fixed;top:0;left:0;right:0;height:2px;width:0;transition:width .2s,opacity .4s;opacity:1;background-color:#efc14e;z-index:999999
 }</style>
   </head>
@@ -21,7 +21,7 @@ exports[`basic /about-us contains EN text, link to /fr/a-propos & link / 1`] = `
 "<!doctype html>
 <html data-n-head-ssr lang=\\"en-US\\" data-n-head=\\"lang\\">
   <head>
-    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"en_US\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-fr-FR\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"fr_FR\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/about-us\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr/a-propos\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"4eb03412:0\\">
+    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"en_US\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-fr-FR\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"fr_FR\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/about-us\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr/a-propos\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"fd547dac:0\\">
 .nuxt-progress{position:fixed;top:0;left:0;right:0;height:2px;width:0;transition:width .2s,opacity .4s;opacity:1;background-color:#efc14e;z-index:999999
 }</style>
   </head>
@@ -38,7 +38,7 @@ exports[`basic /dynamicNested/1/2/3 contains link to /fr/imbrication-dynamique/1
 "<!doctype html>
 <html data-n-head-ssr lang=\\"en-US\\" data-n-head=\\"lang\\">
   <head>
-    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"en_US\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-fr-FR\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"fr_FR\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/dynamicNested/1/2/3\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr/imbrication-dynamique/1/2/3\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"4eb03412:0\\">
+    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"en_US\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-fr-FR\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"fr_FR\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/dynamicNested/1/2/3\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr/imbrication-dynamique/1/2/3\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"fd547dac:0\\">
 .nuxt-progress{position:fixed;top:0;left:0;right:0;height:2px;width:0;transition:width .2s,opacity .4s;opacity:1;background-color:#efc14e;z-index:999999
 }</style>
   </head>
@@ -55,7 +55,7 @@ exports[`basic /fr contains FR text, link to / & link to /fr/a-propos 1`] = `
 "<!doctype html>
 <html data-n-head-ssr lang=\\"fr-FR\\" data-n-head=\\"lang\\">
   <head>
-    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"fr_FR\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-en-US\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"en_US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"4eb03412:0\\">
+    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"fr_FR\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-en-US\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"en_US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"fd547dac:0\\">
 .nuxt-progress{position:fixed;top:0;left:0;right:0;height:2px;width:0;transition:width .2s,opacity .4s;opacity:1;background-color:#efc14e;z-index:999999
 }</style>
   </head>
@@ -72,7 +72,7 @@ exports[`basic /fr/a-propos contains FR text, link to /about-us & link to /fr/ 1
 "<!doctype html>
 <html data-n-head-ssr lang=\\"fr-FR\\" data-n-head=\\"lang\\">
   <head>
-    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"fr_FR\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-en-US\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"en_US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/about-us\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr/a-propos\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"4eb03412:0\\">
+    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"fr_FR\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-en-US\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"en_US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/about-us\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr/a-propos\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"fd547dac:0\\">
 .nuxt-progress{position:fixed;top:0;left:0;right:0;height:2px;width:0;transition:width .2s,opacity .4s;opacity:1;background-color:#efc14e;z-index:999999
 }</style>
   </head>
@@ -89,7 +89,7 @@ exports[`basic /fr/imbrication-dynamique/1/2/3 contains link to /dynamicNested/1
 "<!doctype html>
 <html data-n-head-ssr lang=\\"fr-FR\\" data-n-head=\\"lang\\">
   <head>
-    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"fr_FR\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-en-US\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"en_US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/dynamicNested/1/2/3\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr/imbrication-dynamique/1/2/3\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"4eb03412:0\\">
+    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"fr_FR\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-en-US\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"en_US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/dynamicNested/1/2/3\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr/imbrication-dynamique/1/2/3\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"fd547dac:0\\">
 .nuxt-progress{position:fixed;top:0;left:0;right:0;height:2px;width:0;transition:width .2s,opacity .4s;opacity:1;background-color:#efc14e;z-index:999999
 }</style>
   </head>
@@ -106,7 +106,7 @@ exports[`basic /fr/notlocalized contains FR text 1`] = `
 "<!doctype html>
 <html data-n-head-ssr lang=\\"en-US\\" data-n-head=\\"lang\\">
   <head>
-    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"en_US\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-fr-FR\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"fr_FR\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr/notlocalized\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr/notlocalized\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"4eb03412:0\\">
+    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"en_US\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-fr-FR\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"fr_FR\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr/notlocalized\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr/notlocalized\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"fd547dac:0\\">
 .nuxt-progress{position:fixed;top:0;left:0;right:0;height:2px;width:0;transition:width .2s,opacity .4s;opacity:1;background-color:#efc14e;z-index:999999
 }</style>
   </head>
@@ -123,7 +123,7 @@ exports[`basic /fr/posts contains FR text, link to /posts/ & link to /fr/posts/m
 "<!doctype html>
 <html data-n-head-ssr lang=\\"fr-FR\\" data-n-head=\\"lang\\">
   <head>
-    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"fr_FR\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-en-US\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"en_US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/posts/\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr/posts/\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"4eb03412:0\\">
+    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"fr_FR\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-en-US\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"en_US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/posts/\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr/posts/\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"fd547dac:0\\">
 .nuxt-progress{position:fixed;top:0;left:0;right:0;height:2px;width:0;transition:width .2s,opacity .4s;opacity:1;background-color:#efc14e;z-index:999999
 }</style>
   </head>
@@ -140,7 +140,7 @@ exports[`basic /fr/posts/my-slug contains FR text, post's slug, link to /posts/m
 "<!doctype html>
 <html data-n-head-ssr lang=\\"fr-FR\\" data-n-head=\\"lang\\">
   <head>
-    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"fr_FR\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-en-US\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"en_US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/posts/my-slug\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr/posts/my-slug\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"4eb03412:0\\">
+    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"fr_FR\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-en-US\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"en_US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/posts/my-slug\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr/posts/my-slug\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"fd547dac:0\\">
 .nuxt-progress{position:fixed;top:0;left:0;right:0;height:2px;width:0;transition:width .2s,opacity .4s;opacity:1;background-color:#efc14e;z-index:999999
 }</style>
   </head>
@@ -157,7 +157,7 @@ exports[`basic /posts contains EN text, link to /fr/posts/ & link to /posts/my-s
 "<!doctype html>
 <html data-n-head-ssr lang=\\"en-US\\" data-n-head=\\"lang\\">
   <head>
-    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"en_US\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-fr-FR\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"fr_FR\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/posts/\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr/posts/\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"4eb03412:0\\">
+    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"en_US\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-fr-FR\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"fr_FR\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/posts/\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr/posts/\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"fd547dac:0\\">
 .nuxt-progress{position:fixed;top:0;left:0;right:0;height:2px;width:0;transition:width .2s,opacity .4s;opacity:1;background-color:#efc14e;z-index:999999
 }</style>
   </head>
@@ -174,7 +174,7 @@ exports[`basic /posts/my-slug contains EN text, post's slug, link to /fr/posts/m
 "<!doctype html>
 <html data-n-head-ssr lang=\\"en-US\\" data-n-head=\\"lang\\">
   <head>
-    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"en_US\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-fr-FR\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"fr_FR\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/posts/my-slug\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr/posts/my-slug\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"4eb03412:0\\">
+    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"en_US\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-fr-FR\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"fr_FR\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/posts/my-slug\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr/posts/my-slug\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"fd547dac:0\\">
 .nuxt-progress{position:fixed;top:0;left:0;right:0;height:2px;width:0;transition:width .2s,opacity .4s;opacity:1;background-color:#efc14e;z-index:999999
 }</style>
   </head>
@@ -189,7 +189,7 @@ exports[`basic /posts/my-slug contains EN text, post's slug, link to /fr/posts/m
 
 exports[`basic sets SEO metadata properly 1`] = `
 "
-    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"en_US\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-fr-FR\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"fr_FR\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"4eb03412:0\\">
+    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"en_US\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-fr-FR\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"fr_FR\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"fd547dac:0\\">
 .nuxt-progress{position:fixed;top:0;left:0;right:0;height:2px;width:0;transition:width .2s,opacity .4s;opacity:1;background-color:#efc14e;z-index:999999
 }</style>
   "


### PR DESCRIPTION
This PR exposes the SEO head hook function as `this.$nuxtI18nSeo` on components.

This allows to disable seo head mixin on all components (by setting `seo: false` in nuxt i18n options).
Then it's possible to do this in your app layout (or wherever):
```js
    head () {
      return this.$nuxtI18nSeo()
    },
```
This greatly improves performance as SEO links are not recomputed for every components but only for the layout itself.

This changes is not breaking as the default global registration with the same behaviour remains if `seo: true` in the configuration.

Resolves: #144