### PR TITLE
Update routes.js

### DIFF
--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -91,7 +91,7 @@ exports.makeRoutes = (baseRoutes, {
       )
 
       if (locale === defaultLocale && strategy === STRATEGIES.PREFIX_AND_DEFAULT) {
-        routes.push({ ...localizedRoute, path })
+        routes.push({ ...route, path })
       }
 
       if (shouldAddPrefix) {


### PR DESCRIPTION
This solves the problem where the console receives one warning per route for duplicate routes added, and changes the behavior of nuxt-link from going to the "clean" default path of e.g. /contact to always resolving to e.g. /en/contact