### PR TITLE
Wait for lazy loading promises

### DIFF
--- a/src/templates/utils.js
+++ b/src/templates/utils.js
@@ -20,9 +20,10 @@ export async function loadLanguageAsync (i18n, locale) {
         try {
           const module = await import(/* webpackChunkName: "lang-[request]" */ '~/<%= options.langDir %>' + file)
           const messages = module.default ? module.default : module
-          i18n.setLocaleMessage(locale, typeof messages === 'function' ? await Promise.resolve(messages()) : messages)
+          let result = typeof messages === 'function' ? await Promise.resolve(messages()) : messages
+          i18n.setLocaleMessage(locale, result)
           i18n.loadedLanguages.push(locale)
-          return messages
+          return result
         } catch (error) {
           console.error(error)
         }

--- a/src/templates/utils.js
+++ b/src/templates/utils.js
@@ -20,7 +20,7 @@ export async function loadLanguageAsync (i18n, locale) {
         try {
           const module = await import(/* webpackChunkName: "lang-[request]" */ '~/<%= options.langDir %>' + file)
           const messages = module.default ? module.default : module
-          let result = typeof messages === 'function' ? await Promise.resolve(messages()) : messages
+          const result = typeof messages === 'function' ? await Promise.resolve(messages()) : messages
           i18n.setLocaleMessage(locale, result)
           i18n.loadedLanguages.push(locale)
           return result


### PR DESCRIPTION
According to the docs, lazy loaded locales should be able to return a promise. Doing this creates a warning message ever since nuxt switched to https://github.com/Rich-Harris/devalue .

This pull request prevents this warning. If lazy loading returns a promise, it waits for it before returning from `loadLanguageAsync` and returns the resolved value instead.
Resolves https://github.com/nuxt/nuxt.js/issues/4424 . Related: #161 .