### PR TITLE
[WIP] prefix_none strategy

### DIFF
--- a/docs/options-reference.md
+++ b/docs/options-reference.md
@@ -32,6 +32,7 @@ Here are all the options available when configuring the module and their default
   // - 'prefix_except_default': add locale prefix for every locale except default
   // - 'prefix': add locale prefix for every locale
   // - 'prefix_and_default': add locale prefix for every locale and default
+  // - 'prefix_none': no not add any prefixes and trust the browser and cookie
   strategy: 'prefix_except_default',
 
   // Wether or not the translations should be lazy-loaded, if this is enabled,

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -15,7 +15,8 @@ exports.LOCALE_FILE_KEY = 'file'
 const STRATEGIES = {
   PREFIX: 'prefix',
   PREFIX_EXCEPT_DEFAULT: 'prefix_except_default',
-  PREFIX_AND_DEFAULT: 'prefix_and_default'
+  PREFIX_AND_DEFAULT: 'prefix_and_default',
+  PREFIX_NONE: 'prefix_none'
 }
 
 exports.STRATEGIES = STRATEGIES

--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -82,6 +82,8 @@ exports.makeRoutes = (baseRoutes, {
 
       // Add route prefix if needed
       const shouldAddPrefix = (
+        // No prefix if strategy is PREFIX_NONE
+        strategy !== STRATEGIES.PREFIX_NONE &&
         // No prefix if app uses different locale domains
         !differentDomains &&
         // Only add prefix on top level routes
@@ -90,7 +92,7 @@ exports.makeRoutes = (baseRoutes, {
         !(locale === defaultLocale && strategy === STRATEGIES.PREFIX_EXCEPT_DEFAULT)
       )
 
-      if (locale === defaultLocale && strategy === STRATEGIES.PREFIX_AND_DEFAULT) {
+      if (strategy !== STRATEGIES.PREFIX_NONE && locale === defaultLocale && strategy === STRATEGIES.PREFIX_AND_DEFAULT) {
         routes.push({ ...localizedRoute, path })
       }
 

--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -51,6 +51,7 @@ export default async ({ app, route, store, req }) => {
   // Set instance options
   app.i18n = new VueI18n(<%= JSON.stringify(options.vueI18n) %>)
   app.i18n.locales = <%= JSON.stringify(options.locales) %>
+  app.i18n.strategy = '<%= options.strategy %>'
   app.i18n.defaultLocale = '<%= options.defaultLocale %>'
   app.i18n.differentDomains = <%= options.differentDomains %>
   app.i18n.forwardedHost = <%= options.forwardedHost %>
@@ -67,11 +68,14 @@ export default async ({ app, route, store, req }) => {
     })
   }
 
-  let locale = app.i18n.defaultLocale || null
+  let locale = app.i18n.defaultLocale || 'en'
 
   if (app.i18n.differentDomains) {
     const domainLocale = getLocaleDomain()
     locale = domainLocale ? domainLocale : locale
+  } else if (app.i18n.strategy === 'prefix_none') {
+    // TODO: get locale from cookie
+    locale = 'en'
   } else {
     const routeLocale = getLocaleFromRoute(route, app.i18n.routesNameSeparator, app.i18n.locales)
     locale = routeLocale ? routeLocale : locale

--- a/src/plugins/routing.js
+++ b/src/plugins/routing.js
@@ -66,12 +66,21 @@ function switchLocalePathFactory (i18nPath) {
   }
 }
 
+// function switchLocaleFactory (i18nPath, switchLocalePath) {
+//   return function switchLocale (locale) {
+//     console.log('switchLocale', locale)
+//     this[i18nPath].locale = locale
+//     this.$store.commit('i18n/I18N_SET_LOCALE', locale)
+//     // this[switchLocalePath](locale)
+//   }
+// }
+
 function getRouteBaseNameFactory (contextRoute) {
 
-  const routeGetter  = contextRoute ? route => route || contextRoute :
-  function (route) {
-    return route || this.$route
-  }
+  const routeGetter = contextRoute ? route => route || contextRoute
+    : function (route) {
+      return route || this.$route
+    }
 
   return function getRouteBaseName (route) {
     const routesNameSeparator = '<%= options.routesNameSeparator %>'
@@ -87,6 +96,7 @@ Vue.mixin({
   methods: {
     localePath: localePathFactory('$i18n', '$router'),
     switchLocalePath: switchLocalePathFactory('$i18n'),
+    // switchLocale: switchLocaleFactory('$i18n', 'switchLocalePath'),
     getRouteBaseName: getRouteBaseNameFactory()
   }
 })
@@ -94,6 +104,7 @@ Vue.mixin({
 
 export default ({ app, route }) => {
   app.localePath = localePathFactory('i18n', 'router')
-  app.switchLocalePath = switchLocalePathFactory('i18n'),
+  app.switchLocalePath = switchLocalePathFactory('i18n')
+  // app.switchLocale = switchLocaleFactory('i18n', 'switchLocalePath')
   app.getRouteBaseName = getRouteBaseNameFactory(route)
 }

--- a/test/fixtures/basic/start.js
+++ b/test/fixtures/basic/start.js
@@ -1,0 +1,14 @@
+process.env.PORT = process.env.PORT || 5060
+process.env.NODE_ENV = 'production'
+
+const { Nuxt, Builder } = require('nuxt')
+const config = require('./nuxt.config')
+
+async function start() {
+  const nuxt = new Nuxt(config)
+  await new Builder(nuxt).build()
+  await nuxt.listen(process.env.PORT)
+  console.log(`http://localhost:${process.env.PORT}`)
+}
+
+start()

--- a/test/fixtures/prefix_none/__snapshots__/module.test.js.snap
+++ b/test/fixtures/prefix_none/__snapshots__/module.test.js.snap
@@ -1,0 +1,196 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`basic / contains EN text, link to / & link /about-us 1`] = `
+"<!doctype html>
+<html data-n-head-ssr lang=\\"en-US\\" data-n-head=\\"lang\\">
+  <head>
+    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"en_US\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-fr-FR\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"fr_FR\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"4eb03412:0\\">
+.nuxt-progress{position:fixed;top:0;left:0;right:0;height:2px;width:0;transition:width .2s,opacity .4s;opacity:1;background-color:#efc14e;z-index:999999
+}</style>
+  </head>
+  <body data-n-head=\\"\\">
+    <div data-server-rendered=\\"true\\" id=\\"__nuxt\\"><div class=\\"nuxt-progress\\" style=\\"width:0%;height:2px;background-color:black;opacity:0;\\"></div><div id=\\"__layout\\"><div><div><!----><a href=\\"/\\" class=\\"nuxt-link-exact-active nuxt-link-active\\">Français</a></div>
+  Homepage
+  <a href=\\"/about-us\\">About us</a></div></div></div>
+  </body>
+</html>
+"
+`;
+
+exports[`basic / contains FR text, link to / & link to /a-propos 1`] = `
+"<!doctype html>
+<html data-n-head-ssr lang=\\"fr-FR\\" data-n-head=\\"lang\\">
+  <head>
+    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"fr_FR\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-en-US\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"en_US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"4eb03412:0\\">
+.nuxt-progress{position:fixed;top:0;left:0;right:0;height:2px;width:0;transition:width .2s,opacity .4s;opacity:1;background-color:#efc14e;z-index:999999
+}</style>
+  </head>
+  <body data-n-head=\\"\\">
+    <div data-server-rendered=\\"true\\" id=\\"__nuxt\\"><div class=\\"nuxt-progress\\" style=\\"width:0%;height:2px;background-color:black;opacity:0;\\"></div><div id=\\"__layout\\"><div><div><a href=\\"/\\" class=\\"nuxt-link-exact-active nuxt-link-active\\">English</a><!----></div>
+  Accueil
+  <a href=\\"/a-propos\\">À propos</a></div></div></div>
+  </body>
+</html>
+"
+`;
+
+exports[`basic /a-propos contains FR text, link to /about-us & link to / 1`] = `
+"<!doctype html>
+<html data-n-head-ssr lang=\\"fr-FR\\" data-n-head=\\"lang\\">
+  <head>
+    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"fr_FR\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-en-US\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"en_US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/about-us\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/a-propos\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"4eb03412:0\\">
+.nuxt-progress{position:fixed;top:0;left:0;right:0;height:2px;width:0;transition:width .2s,opacity .4s;opacity:1;background-color:#efc14e;z-index:999999
+}</style>
+  </head>
+  <body data-n-head=\\"\\">
+    <div data-server-rendered=\\"true\\" id=\\"__nuxt\\"><div class=\\"nuxt-progress\\" style=\\"width:0%;height:2px;background-color:black;opacity:0;\\"></div><div id=\\"__layout\\"><div><div><a href=\\"/about-us\\">English</a><!----></div>
+  À propos
+  <a href=\\"/\\">Accueil</a></div></div></div>
+  </body>
+</html>
+"
+`;
+
+exports[`basic /about-us contains EN text, link to /a-propos & link / 1`] = `
+"<!doctype html>
+<html data-n-head-ssr lang=\\"en-US\\" data-n-head=\\"lang\\">
+  <head>
+    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"en_US\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-fr-FR\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"fr_FR\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/about-us\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/a-propos\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"4eb03412:0\\">
+.nuxt-progress{position:fixed;top:0;left:0;right:0;height:2px;width:0;transition:width .2s,opacity .4s;opacity:1;background-color:#efc14e;z-index:999999
+}</style>
+  </head>
+  <body data-n-head=\\"\\">
+    <div data-server-rendered=\\"true\\" id=\\"__nuxt\\"><div class=\\"nuxt-progress\\" style=\\"width:0%;height:2px;background-color:black;opacity:0;\\"></div><div id=\\"__layout\\"><div><div><!----><a href=\\"/a-propos\\">Français</a></div>
+  About us
+  <a href=\\"/\\">Homepage</a></div></div></div>
+  </body>
+</html>
+"
+`;
+
+exports[`basic /dynamicNested/1/2/3 contains link to /imbrication-dynamique/1/2/3 1`] = `
+"<!doctype html>
+<html data-n-head-ssr lang=\\"en-US\\" data-n-head=\\"lang\\">
+  <head>
+    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"en_US\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-fr-FR\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"fr_FR\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/dynamicNested/1/2/3\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/imbrication-dynamique/1/2/3\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"4eb03412:0\\">
+.nuxt-progress{position:fixed;top:0;left:0;right:0;height:2px;width:0;transition:width .2s,opacity .4s;opacity:1;background-color:#efc14e;z-index:999999
+}</style>
+  </head>
+  <body data-n-head=\\"\\">
+    <div data-server-rendered=\\"true\\" id=\\"__nuxt\\"><div class=\\"nuxt-progress\\" style=\\"width:0%;height:2px;background-color:black;opacity:0;\\"></div><div id=\\"__layout\\"><div>
+  Category 1
+  <div><div>Subcategory 2</div> <div>Post 3</div> <div><!----><a href=\\"/imbrication-dynamique/1/2/3\\">Français</a></div></div></div></div></div>
+  </body>
+</html>
+"
+`;
+
+exports[`basic /fr/notlocalized contains FR text 1`] = `
+"<!doctype html>
+<html data-n-head-ssr lang=\\"en-US\\" data-n-head=\\"lang\\">
+  <head>
+    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"en_US\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-fr-FR\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"fr_FR\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr/notlocalized\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/fr/notlocalized\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"4eb03412:0\\">
+.nuxt-progress{position:fixed;top:0;left:0;right:0;height:2px;width:0;transition:width .2s,opacity .4s;opacity:1;background-color:#efc14e;z-index:999999
+}</style>
+  </head>
+  <body data-n-head=\\"\\">
+    <div data-server-rendered=\\"true\\" id=\\"__nuxt\\"><div class=\\"nuxt-progress\\" style=\\"width:0%;height:2px;background-color:black;opacity:0;\\"></div><div id=\\"__layout\\"><div>
+  FR only
+</div></div></div>
+  </body>
+</html>
+"
+`;
+
+exports[`basic /imbrication-dynamique/1/2/3 contains link to /dynamicNested/1/2/3 1`] = `
+"<!doctype html>
+<html data-n-head-ssr lang=\\"fr-FR\\" data-n-head=\\"lang\\">
+  <head>
+    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"fr_FR\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-en-US\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"en_US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/dynamicNested/1/2/3\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/imbrication-dynamique/1/2/3\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"4eb03412:0\\">
+.nuxt-progress{position:fixed;top:0;left:0;right:0;height:2px;width:0;transition:width .2s,opacity .4s;opacity:1;background-color:#efc14e;z-index:999999
+}</style>
+  </head>
+  <body data-n-head=\\"\\">
+    <div data-server-rendered=\\"true\\" id=\\"__nuxt\\"><div class=\\"nuxt-progress\\" style=\\"width:0%;height:2px;background-color:black;opacity:0;\\"></div><div id=\\"__layout\\"><div>
+  Category 1
+  <div><div>Subcategory 2</div> <div>Post 3</div> <div><a href=\\"/dynamicNested/1/2/3\\">English</a><!----></div></div></div></div></div>
+  </body>
+</html>
+"
+`;
+
+exports[`basic /posts contains EN text, link to /posts/ & link to /posts/my-slug 1`] = `
+"<!doctype html>
+<html data-n-head-ssr lang=\\"en-US\\" data-n-head=\\"lang\\">
+  <head>
+    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"en_US\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-fr-FR\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"fr_FR\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/posts/\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/posts/\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"4eb03412:0\\">
+.nuxt-progress{position:fixed;top:0;left:0;right:0;height:2px;width:0;transition:width .2s,opacity .4s;opacity:1;background-color:#efc14e;z-index:999999
+}</style>
+  </head>
+  <body data-n-head=\\"\\">
+    <div data-server-rendered=\\"true\\" id=\\"__nuxt\\"><div class=\\"nuxt-progress\\" style=\\"width:0%;height:2px;background-color:black;opacity:0;\\"></div><div id=\\"__layout\\"><div><div><!----><a href=\\"/posts/\\" class=\\"nuxt-link-exact-active nuxt-link-active\\">Français</a></div>
+  Posts
+  <div><a href=\\"/posts/my-slug\\">my-slug</a></div></div></div></div>
+  </body>
+</html>
+"
+`;
+
+exports[`basic /posts contains FR text, link to /posts/ & link to /posts/my-slug 1`] = `
+"<!doctype html>
+<html data-n-head-ssr lang=\\"fr-FR\\" data-n-head=\\"lang\\">
+  <head>
+    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"fr_FR\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-en-US\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"en_US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/posts/\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/posts/\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"4eb03412:0\\">
+.nuxt-progress{position:fixed;top:0;left:0;right:0;height:2px;width:0;transition:width .2s,opacity .4s;opacity:1;background-color:#efc14e;z-index:999999
+}</style>
+  </head>
+  <body data-n-head=\\"\\">
+    <div data-server-rendered=\\"true\\" id=\\"__nuxt\\"><div class=\\"nuxt-progress\\" style=\\"width:0%;height:2px;background-color:black;opacity:0;\\"></div><div id=\\"__layout\\"><div><div><a href=\\"/posts/\\" class=\\"nuxt-link-exact-active nuxt-link-active\\">English</a><!----></div>
+  Articles
+  <div><a href=\\"/posts/my-slug\\">my-slug</a></div></div></div></div>
+  </body>
+</html>
+"
+`;
+
+exports[`basic /posts/my-slug contains EN text, post's slug, link to /posts/my-slug & link to /posts/ 1`] = `
+"<!doctype html>
+<html data-n-head-ssr lang=\\"en-US\\" data-n-head=\\"lang\\">
+  <head>
+    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"en_US\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-fr-FR\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"fr_FR\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/posts/my-slug\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/posts/my-slug\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"4eb03412:0\\">
+.nuxt-progress{position:fixed;top:0;left:0;right:0;height:2px;width:0;transition:width .2s,opacity .4s;opacity:1;background-color:#efc14e;z-index:999999
+}</style>
+  </head>
+  <body data-n-head=\\"\\">
+    <div data-server-rendered=\\"true\\" id=\\"__nuxt\\"><div class=\\"nuxt-progress\\" style=\\"width:0%;height:2px;background-color:black;opacity:0;\\"></div><div id=\\"__layout\\"><div><div><!----><a href=\\"/posts/my-slug\\" class=\\"nuxt-link-exact-active nuxt-link-active\\">Français</a></div>
+  Posts
+  <div><h1>my-slug</h1> <a href=\\"/posts/\\">index</a></div></div></div></div>
+  </body>
+</html>
+"
+`;
+
+exports[`basic /posts/my-slug contains FR text, post's slug, link to /posts/my-slug & link to /posts/ 1`] = `
+"<!doctype html>
+<html data-n-head-ssr lang=\\"fr-FR\\" data-n-head=\\"lang\\">
+  <head>
+    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"fr_FR\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-en-US\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"en_US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/posts/my-slug\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/posts/my-slug\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"4eb03412:0\\">
+.nuxt-progress{position:fixed;top:0;left:0;right:0;height:2px;width:0;transition:width .2s,opacity .4s;opacity:1;background-color:#efc14e;z-index:999999
+}</style>
+  </head>
+  <body data-n-head=\\"\\">
+    <div data-server-rendered=\\"true\\" id=\\"__nuxt\\"><div class=\\"nuxt-progress\\" style=\\"width:0%;height:2px;background-color:black;opacity:0;\\"></div><div id=\\"__layout\\"><div><div><a href=\\"/posts/my-slug\\" class=\\"nuxt-link-exact-active nuxt-link-active\\">English</a><!----></div>
+  Articles
+  <div><h1>my-slug</h1> <a href=\\"/posts/\\">index</a></div></div></div></div>
+  </body>
+</html>
+"
+`;
+
+exports[`basic sets SEO metadata properly 1`] = `
+"
+    <title data-n-head=\\"true\\"></title><meta data-n-head=\\"true\\" data-hid=\\"og:locale\\" name=\\"og:locale\\" property=\\"og:locale\\" content=\\"en_US\\"/><meta data-n-head=\\"true\\" data-hid=\\"og:locale:alternate-fr-FR\\" name=\\"og:locale:alternate\\" property=\\"og:locale:alternate\\" content=\\"fr_FR\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-en-US\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/\\" hreflang=\\"en-US\\"/><link data-n-head=\\"true\\" data-hid=\\"alternate-hreflang-fr-FR\\" rel=\\"alternate\\" href=\\"nuxt-app.localhost/\\" hreflang=\\"fr-FR\\"/><style data-vue-ssr-id=\\"4eb03412:0\\">
+.nuxt-progress{position:fixed;top:0;left:0;right:0;height:2px;width:0;transition:width .2s,opacity .4s;opacity:1;background-color:#efc14e;z-index:999999
+}</style>
+  "
+`;

--- a/test/fixtures/prefix_none/components/LangSwitcher.vue
+++ b/test/fixtures/prefix_none/components/LangSwitcher.vue
@@ -1,0 +1,18 @@
+<template>
+  <div>
+    <nuxt-link
+      v-for="(locale, index) in $i18n.locales"
+      v-if="locale.code !== $i18n.locale"
+      :key="index"
+      :exact="true"
+      :to="`/${locale.code}${switchLocalePath(locale.code)}`"
+      @click="$i18n.switchLocale(locale.code)">{{ locale.name }}</nuxt-link>
+      <!-- @click.prevent="$i18n.switchLocale(locale.code)" -->
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'LangSwitcher'
+}
+</script>

--- a/test/fixtures/prefix_none/module.test.js
+++ b/test/fixtures/prefix_none/module.test.js
@@ -1,0 +1,106 @@
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000
+process.env.PORT = process.env.PORT || 5060
+process.env.NODE_ENV = 'production'
+
+const { Nuxt, Builder } = require('nuxt')
+const request = require('request-promise-native')
+
+const config = require('./nuxt.config')
+
+const { cleanUpScripts } = require('../../utils')
+
+const url = path => `http://localhost:${process.env.PORT}${path}`
+const get = params => request(Object.assign(params, { uri: url(params.uri) }))
+
+describe('basic', () => {
+  let nuxt
+
+  beforeAll(async () => {
+    nuxt = new Nuxt(config)
+    await new Builder(nuxt).build()
+    await nuxt.listen(process.env.PORT)
+  })
+
+  afterAll(async () => {
+    await nuxt.close()
+  })
+
+  test('sets SEO metadata properly', async () => {
+    const html = await get({ uri: '/', headers: { 'Accept-Language': 'en-US' } })
+    const match = html.match(/<head>((.|\n)*)<\/head>/)
+    expect(match.length).toBeGreaterThanOrEqual(2)
+    const head = match[1]
+    expect(head).toMatchSnapshot()
+  })
+
+  test('/ contains EN text, link to / & link /about-us', async () => {
+    let html = await get({ uri: '/', headers: { 'Accept-Language': 'en-US' } })
+    expect(cleanUpScripts(html)).toMatchSnapshot()
+  })
+
+  test('/ contains FR text, link to / & link to /a-propos', async () => {
+    let html = await get({ uri: '/', headers: { 'Accept-Language': 'fr-FR' } })
+    expect(cleanUpScripts(html)).toMatchSnapshot()
+  })
+
+  test('/about-us contains EN text, link to /a-propos & link /', async () => {
+    let html = await get({ uri: '/about-us', headers: { 'Accept-Language': 'en-US' } })
+    expect(cleanUpScripts(html)).toMatchSnapshot()
+  })
+
+  test('/a-propos contains FR text, link to /about-us & link to /', async () => {
+    let html = await get({ uri: '/a-propos', headers: { 'Accept-Language': 'fr-FR' } })
+    expect(cleanUpScripts(html)).toMatchSnapshot()
+  })
+
+  test('/fr/notlocalized contains FR text', async () => {
+    let html = await get({ uri: '/fr/notlocalized', headers: { 'Accept-Language': 'en-US' } })
+    expect(cleanUpScripts(html)).toMatchSnapshot()
+  })
+
+  test('/notlocalized & /fr/fr/notlocalized return 404', async () => {
+    let response
+    try {
+      response = await get({ uri: '/notlocalized' })
+    } catch (error) {
+      response = error
+    }
+    expect(response.statusCode).toBe(404)
+    try {
+      response = await get({ uri: '/fr/fr/notlocalized' })
+    } catch (error) {
+      response = error
+    }
+    expect(response.statusCode).toBe(404)
+  })
+
+  test('/posts contains EN text, link to /posts/ & link to /posts/my-slug', async () => {
+    let html = await get({ uri: '/posts', headers: { 'Accept-Language': 'en-US' } })
+    expect(cleanUpScripts(html)).toMatchSnapshot()
+  })
+
+  test('/posts/my-slug contains EN text, post\'s slug, link to /posts/my-slug & link to /posts/', async () => {
+    let html = await get({ uri: '/posts/my-slug', headers: { 'Accept-Language': 'en-US' } })
+    expect(cleanUpScripts(html)).toMatchSnapshot()
+  })
+
+  test('/posts contains FR text, link to /posts/ & link to /posts/my-slug', async () => {
+    let html = await get({ uri: '/posts', headers: { 'Accept-Language': 'fr-FR' } })
+    expect(cleanUpScripts(html)).toMatchSnapshot()
+  })
+
+  test('/posts/my-slug contains FR text, post\'s slug, link to /posts/my-slug & link to /posts/', async () => {
+    let html = await get({ uri: '/posts/my-slug', headers: { 'Accept-Language': 'fr-FR' } })
+    expect(cleanUpScripts(html)).toMatchSnapshot()
+  })
+
+  test('/dynamicNested/1/2/3 contains link to /imbrication-dynamique/1/2/3', async () => {
+    let html = await get({ uri: '/dynamicNested/1/2/3', headers: { 'Accept-Language': 'en-US' } })
+    expect(cleanUpScripts(html)).toMatchSnapshot()
+  })
+
+  test('/imbrication-dynamique/1/2/3 contains link to /dynamicNested/1/2/3', async () => {
+    let html = await get({ uri: '/imbrication-dynamique/1/2/3', headers: { 'Accept-Language': 'en-US' } })
+    expect(cleanUpScripts(html)).toMatchSnapshot()
+  })
+})

--- a/test/fixtures/prefix_none/nuxt.config.js
+++ b/test/fixtures/prefix_none/nuxt.config.js
@@ -1,0 +1,43 @@
+module.exports = {
+  srcDir: __dirname,
+  dev: false,
+  render: {
+    resourceHints: false
+  },
+  modules: [
+    ['@@', {
+      seo: true,
+      baseUrl: 'nuxt-app.localhost',
+      locales: [
+        {
+          code: 'en',
+          iso: 'en-US',
+          name: 'English'
+        },
+        {
+          code: 'fr',
+          iso: 'fr-FR',
+          name: 'Français'
+        }
+      ],
+      strategy: 'prefix_none',
+      defaultLocale: 'en',
+      lazy: false,
+      vueI18n: {
+        messages: {
+          fr: {
+            home: 'Accueil',
+            about: 'À propos',
+            posts: 'Articles'
+          },
+          en: {
+            home: 'Homepage',
+            about: 'About us',
+            posts: 'Posts'
+          }
+        },
+        fallbackLocale: 'en'
+      }
+    }]
+  ]
+}

--- a/test/fixtures/prefix_none/pages/about.vue
+++ b/test/fixtures/prefix_none/pages/about.vue
@@ -1,0 +1,23 @@
+<template>
+<div>
+  <LangSwitcher />
+  {{ $t('about') }}
+  <nuxt-link exact :to="localePath('index')">{{ $t('home') }}</nuxt-link>
+</div>
+</template>
+
+<script>
+import LangSwitcher from '../components/LangSwitcher'
+
+export default {
+  components: {
+    LangSwitcher
+  },
+  nuxtI18n: {
+    paths: {
+      en: '/about-us',
+      fr: '/a-propos'
+    }
+  }
+}
+</script>

--- a/test/fixtures/prefix_none/pages/dynamicNested/_category.vue
+++ b/test/fixtures/prefix_none/pages/dynamicNested/_category.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    Category {{ $route.params.category }}
+    <nuxt-child></nuxt-child>
+  </div>
+</template>
+
+<script>
+export default {
+  nuxtI18n: {
+    paths: {
+      fr: '/imbrication-dynamique/:category'
+    }
+  }
+}
+</script>

--- a/test/fixtures/prefix_none/pages/dynamicNested/_category/_subCategory/_id.vue
+++ b/test/fixtures/prefix_none/pages/dynamicNested/_category/_subCategory/_id.vue
@@ -1,0 +1,17 @@
+<template>
+  <div>
+    <div>Subcategory {{ $route.params.subCategory }}</div>
+    <div>Post {{ $route.params.id }}</div>
+    <LangSwitcher />
+  </div>
+</template>
+
+<script>
+import LangSwitcher from '../../../../components/LangSwitcher'
+
+export default {
+  components: {
+    LangSwitcher
+  }
+}
+</script>

--- a/test/fixtures/prefix_none/pages/dynamicNested/_category/_subCategory/index.vue
+++ b/test/fixtures/prefix_none/pages/dynamicNested/_category/_subCategory/index.vue
@@ -1,0 +1,9 @@
+<template>
+  <div>
+    Subcategory {{ $route.params.subCategory }}
+  </div>
+</template>
+
+<script>
+export default {}
+</script>

--- a/test/fixtures/prefix_none/pages/dynamicNested/index.vue
+++ b/test/fixtures/prefix_none/pages/dynamicNested/index.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    Dynamic nested example
+  </div>
+</template>
+
+<script>
+export default {
+  nuxtI18n: {
+    paths: {
+      fr: '/imbrication-dynamique'
+    }
+  }
+}
+</script>

--- a/test/fixtures/prefix_none/pages/fr/notlocalized.vue
+++ b/test/fixtures/prefix_none/pages/fr/notlocalized.vue
@@ -1,0 +1,11 @@
+<template>
+<div>
+  FR only
+</div>
+</template>
+
+<script>
+export default {
+  nuxtI18n: false
+}
+</script>

--- a/test/fixtures/prefix_none/pages/index.vue
+++ b/test/fixtures/prefix_none/pages/index.vue
@@ -1,0 +1,17 @@
+<template>
+<div>
+  <LangSwitcher />
+  {{ $t('home') }}
+  <nuxt-link exact :to="localePath('about')">{{ $t('about') }}</nuxt-link>
+</div>
+</template>
+
+<script>
+import LangSwitcher from '../components/LangSwitcher'
+
+export default {
+  components: {
+    LangSwitcher
+  }
+}
+</script>

--- a/test/fixtures/prefix_none/pages/posts.vue
+++ b/test/fixtures/prefix_none/pages/posts.vue
@@ -1,0 +1,17 @@
+<template>
+<div>
+  <LangSwitcher />
+  {{ $t('posts') }}
+  <router-view></router-view>
+</div>
+</template>
+
+<script>
+import LangSwitcher from '../components/LangSwitcher'
+
+export default {
+  components: {
+    LangSwitcher
+  }
+}
+</script>

--- a/test/fixtures/prefix_none/pages/posts/_slug.vue
+++ b/test/fixtures/prefix_none/pages/posts/_slug.vue
@@ -1,0 +1,18 @@
+<template>
+<div>
+  <h1>{{ $route.params.slug }}</h1>
+  <nuxt-link
+    exact
+    :to="localePath('posts')">index</nuxt-link>
+</div>
+</template>
+
+<script>
+import LangSwitcher from '../../components/LangSwitcher'
+
+export default {
+  components: {
+    LangSwitcher
+  }
+}
+</script>

--- a/test/fixtures/prefix_none/pages/posts/index.vue
+++ b/test/fixtures/prefix_none/pages/posts/index.vue
@@ -1,0 +1,27 @@
+<template>
+<div>
+  <nuxt-link
+    exact
+    :to="localePath({
+      name: 'posts-slug',
+      params: {
+        slug: 'my-slug'
+      }
+    })">my-slug</nuxt-link>
+</div>
+</template>
+
+<script>
+import LangSwitcher from '../../components/LangSwitcher'
+
+export default {
+  components: {
+    LangSwitcher
+  },
+  nuxtI18n: {
+    paths: {
+      fr: '/poste/:slug'
+    }
+  }
+}
+</script>

--- a/test/fixtures/prefix_none/start.js
+++ b/test/fixtures/prefix_none/start.js
@@ -1,0 +1,14 @@
+process.env.PORT = process.env.PORT || 5060
+process.env.NODE_ENV = 'production'
+
+const { Nuxt, Builder } = require('nuxt')
+const config = require('./nuxt.config')
+
+async function start() {
+  const nuxt = new Nuxt(config)
+  await new Builder(nuxt).build()
+  await nuxt.listen(process.env.PORT)
+  console.log(`http://localhost:${process.env.PORT}`)
+}
+
+start()


### PR DESCRIPTION
I need to be able to switch the language without a prefix as the locale is only used for the interface, not for the content (which can be multilingual).

Therefore I startet to add a `PREFIX_NONE` strategy.

> I would be happy for some feedback

## Problems to solve:
- [x] do not prefix links
- [ ] fix locale switch (currenty does not work on the root route `/`)
- [x] write tests for the `PREFIX_NONE` strategy (found in `test/fixture/prefix_none/`)
- [ ] more link tests
- [ ] clean up code

## How to test
- **in browser:** `node test/fixtures/prefix_none/start.js` or `node test/fixtures/basic/start.js`
- **run tests:** `yarn jest test/fixtures/prefix_none` or `yarn jest test/fixtures/basic`