### PR TITLE
Update types

### DIFF
--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -3,12 +3,12 @@
  */
 
 import Vue from "vue";
-import { Route } from "vue-router";
+import { RawLocation } from "vue-router";
 
 declare module "vue/types/vue" {
   interface Vue {
-    localePath(route: string | Route, locale?: string): string;
+    localePath(route: string | RawLocation, locale?: string): string;
     switchLocalePath(locale: string): string;
-    getRouteBaseName(route: Route): string;
+    getRouteBaseName(route: RawLocation): string;
   }
 }

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -7,7 +7,7 @@ import { RawLocation } from "vue-router";
 
 declare module "vue/types/vue" {
   interface Vue {
-    localePath(route: string | RawLocation, locale?: string): string;
+    localePath(route: RawLocation, locale?: string): string;
     switchLocalePath(locale: string): string;
     getRouteBaseName(route: RawLocation): string;
   }


### PR DESCRIPTION
That's what RawLocation is:

```ts
export type RawLocation = string | Location;

export interface Location {
  name?: string;
  path?: string;
  hash?: string;
  query?: Dictionary<string | string[]>;
  params?: Dictionary<string>;
  append?: boolean;
  replace?: boolean;
}
```
This type, for example, is used in the "push" method:

```ts
push (location: RawLocation, onComplete?: Function, onAbort?: ErrorHandler): void;
```

Without this fix, I had a error:

![image](https://user-images.githubusercontent.com/13103045/49702842-faf20080-fc05-11e8-9fd6-a1be64c475df.png)
