### PR TITLE
Update main.js

### DIFF
--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -57,6 +57,10 @@ export default async ({ app, route, store, req }) => {
   app.i18n.routesNameSeparator = '<%= options.routesNameSeparator %>'
   app.i18n.beforeLanguageSwitch = <%= options.beforeLanguageSwitch %>
   app.i18n.onLanguageSwitched = <%= options.onLanguageSwitched %>
+  // Extension of Vue
+  if (!app.$t) {
+    app.$t = app.i18n.t
+  }
 
   // Inject seo function
   Vue.prototype.$nuxtI18nSeo = nuxtI18nSeo


### PR DESCRIPTION
This will take [this method](https://kazupon.github.io/vue-i18n/api/#methods) to the app object, it will be convenient to use on the server.

For, example, instead of this:
```js
app.i18n.t('posts_page_error_404')
```
can be used:
```js
app.$t('posts_page_error_404')
```