### PR TITLE
rootRedirect's redirect does not preserve query

### DIFF
--- a/src/templates/middleware.js
+++ b/src/templates/middleware.js
@@ -27,7 +27,7 @@ middleware['i18n'] = async ({ app, req, res, route, store, redirect, isHMR }) =>
   // Handle root path redirect
   const rootRedirect = '<%= options.rootRedirect %>'
   if (route.path === '/' && rootRedirect) {
-    redirect('/' + rootRedirect)
+    redirect('/' + rootRedirect, route.query)
     return
   }
 


### PR DESCRIPTION
**Case:** user enters the website on root path ( '/' ) with some query params. a common case of this is tracking query params.

**Current Behavior:** query params are lost when redirected to rootRedirect

**Desired Behavior:** user will redirect to the rootRedirect URL with the query params he had

This fixes the problem and preserves the query.