### PR TITLE
 fix duplicate route names with prefix_and_default strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="5.5.1"></a>
+## [5.5.1](https://github.com/nuxt-community/nuxt-i18n/compare/v5.5.0...v5.5.1) (2018-12-24)
+
+
+
 <a name="5.5.0"></a>
 # [5.5.0](https://github.com/nuxt-community/nuxt-i18n/compare/v5.4.4...v5.5.0) (2018-12-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="5.5.0"></a>
+# [5.5.0](https://github.com/nuxt-community/nuxt-i18n/compare/v5.4.4...v5.5.0) (2018-12-24)
+
+
+### Features
+
+* expose head SEO function to use in layout ([#154](https://github.com/nuxt-community/nuxt-i18n/issues/154)) ([ce373c4](https://github.com/nuxt-community/nuxt-i18n/commit/ce373c4))
+* rework browser detection and save lang to cookie ([#148](https://github.com/nuxt-community/nuxt-i18n/issues/148)) ([d1bbc84](https://github.com/nuxt-community/nuxt-i18n/commit/d1bbc84))
+
+
+
 <a name="5.4.4"></a>
 ## [5.4.4](https://github.com/nuxt-community/nuxt-i18n/compare/v5.4.3...v5.4.4) (2018-10-23)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "nuxt-i18n",
-  "version": "5.5.0",
+  "name": "@souvenir/nuxt-i18n",
+  "version": "5.5.1",
   "description": "i18n for Nuxt",
   "license": "MIT",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-i18n",
-  "version": "5.4.4",
+  "version": "5.5.0",
   "description": "i18n for Nuxt",
   "license": "MIT",
   "contributors": [

--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -91,7 +91,7 @@ exports.makeRoutes = (baseRoutes, {
       )
 
       if (locale === defaultLocale && strategy === STRATEGIES.PREFIX_AND_DEFAULT) {
-        routes.push({ ...localizedRoute, path })
+        routes.push({ ...route, path })
       }
 
       if (shouldAddPrefix) {


### PR DESCRIPTION

fix duplicate route names with prefix_and_default strategy