### PR TITLE
New strategy NO_PREFIX

### DIFF
--- a/docs/options-reference.md
+++ b/docs/options-reference.md
@@ -32,6 +32,7 @@ Here are all the options available when configuring the module and their default
   // - 'prefix_except_default': add locale prefix for every locale except default
   // - 'prefix': add locale prefix for every locale
   // - 'prefix_and_default': add locale prefix for every locale and default
+  // - 'no_prefix': don't add locale prefix
   strategy: 'prefix_except_default',
 
   // Wether or not the translations should be lazy-loaded, if this is enabled,

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -40,7 +40,7 @@ Note that routes for the English version do not have any prefix because it is th
 
 ## Strategy
 
-There are two supported strategies for generating the app's routes:
+There are four supported strategies for generating the app's routes:
 
 ### prefix_except_default
 
@@ -53,6 +53,10 @@ With this strategy, all routes will have a locale prefix.
 ### prefix_and_default
 
 This strategy combines both previous strategies behaviours, meaning that you will get URLs with prefixes for every language, but URLs for the default language will also have a non-prefixed version.
+
+### no_prefix
+
+This strategy allows you to create custom paths without any prefixes.
 
 To configure the strategy, use the `strategy` option. Make sure you have a `defaultLocale` defined if using **prefix_except_default**  or **prefix_and_default** strategy.
 

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -15,7 +15,8 @@ exports.LOCALE_FILE_KEY = 'file'
 const STRATEGIES = {
   PREFIX: 'prefix',
   PREFIX_EXCEPT_DEFAULT: 'prefix_except_default',
-  PREFIX_AND_DEFAULT: 'prefix_and_default'
+  PREFIX_AND_DEFAULT: 'prefix_and_default',
+  NO_PREFIX: 'no_prefix'
 }
 
 exports.STRATEGIES = STRATEGIES

--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -82,6 +82,8 @@ exports.makeRoutes = (baseRoutes, {
 
       // Add route prefix if needed
       const shouldAddPrefix = (
+        // No prefix if stragety is NO_PREFIX
+        strategy !== STRATEGIES.NO_PREFIX &&
         // No prefix if app uses different locale domains
         !differentDomains &&
         // Only add prefix on top level routes


### PR DESCRIPTION
### What is the problem:

I want to have a custom URL path for every link, so I want to have something like this:
* /kontakt
* /contact

But instead it seems like the only option nuxt-i18n gives me is:
* /kontakt
* /en/contact

### How I fixed it:

I added a new strategy called **NO_PREFIX**. It is chosen by the user in the nuxt config file with **'no_prefix'**. I've also updated some docs to reflect the changes.

Suggested here:
* https://cmty.app/nuxt/nuxt-i18n/issues/c166
* https://cmty.app/nuxt/nuxt-i18n/issues/c184 (by me, excerpt used to explain)
