### PR TITLE
Fix state not defined issue in #173

### DIFF
--- a/docs/options-reference.md
+++ b/docs/options-reference.md
@@ -58,7 +58,7 @@ Here are all the options available when configuring the module and their default
     cookieKey: 'i18n_redirected',
     // Set to always redirect to value stored in the cookie, not just once
     alwaysRedirect: false,
-    // If no locale for the browsers locale is a match, use this one as a fallback 
+    // If no locale for the browsers locale is a match, use this one as a fallback
     fallbackLocale: null
   },
 
@@ -84,7 +84,7 @@ Here are all the options available when configuring the module and their default
   vuex: {
     // Module namespace
     moduleName: 'i18n',
-    
+
     // Mutations config
     mutations: {
       // Mutation to commit to store current locale, set to false to disable
@@ -92,7 +92,10 @@ Here are all the options available when configuring the module and their default
 
       // Mutation to commit to store current message, set to false to disable
       setMessages: 'I18N_SET_MESSAGES'
-    }
+    },
+
+    // PreserveState from server
+    preserveState: false
   },
 
   // By default, custom routes are extracted from page files using acorn parsing,

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -46,7 +46,8 @@ exports.DEFAULT_OPTIONS = {
     mutations: {
       setLocale: 'I18N_SET_LOCALE',
       setMessages: 'I18N_SET_MESSAGES'
-    }
+    },
+    preserveState: false
   },
   parsePages: true,
   pages: {},

--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -44,7 +44,7 @@ export default async ({ app, route, store, req }) => {
           state.messages = messages
         }
       }
-    })
+    }, { preserveState: false })
   }
   <% } %>
 

--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -44,7 +44,7 @@ export default async ({ app, route, store, req }) => {
           state.messages = messages
         }
       }
-    }, { preserveState: false })
+    }, { preserveState: vuex.preserveState })
   }
   <% } %>
 


### PR DESCRIPTION
This PR fixes https://github.com/nuxt-community/nuxt-i18n/pull/173

The problem occurs when deploying with SSR to a static host, such as AWS S3, then access `https://example.com/en`. Since there is no matching file,  Nuxt loads the fallback file `https://example.com/200.html`.

Now due to there is no server rendered state value defined(https://nuxtjs.org/guide/vuex-store#modules-mode), client preserves the state without the i18n module state, which raised an exception later when trying to set the locale.

The fix is to set `{ preserveState: false }` by default. If need to pass value from the server, then set`preserveState` to true in the options, and create a module vuex file as described here: https://nuxtjs.org/guide/vuex-store#modules-mode 