### PR TITLE
Fixed link to CMTY.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ yarn docs:dev
 
 ## Issues, questions & requests
 
-Please use [CMTY](https://cmty.app/nuxt/nuxt-i18n/issues) for any question you might have.
+Please use [CMTY](https://cmty.app/nuxt/nuxt-i18n/issues?type=question) for any question you might have.
 
 
 ## License


### PR DESCRIPTION
Link was pointing to non-existing page. Added query parameter to make it point to questions.

If it should point to all kinds of issues then perhaps even https://cmty.app/nuxt/nuxt-i18n/ would be even better as link location.