### PR TITLE
Creates correct baseroute for switchlocalepath

### DIFF
--- a/src/plugins/routing.js
+++ b/src/plugins/routing.js
@@ -43,9 +43,9 @@ function switchLocalePathFactory (i18nPath) {
     if (!name) {
       return ''
     }
-
-		const { params, ...routeCopy } = this.$route
-		const baseRoute = Object.assign({}, routeCopy, { name, params: { '0': params.pathMatch } })
+    
+    const { params, ...routeCopy } = this.$route
+    const baseRoute = Object.assign({}, routeCopy, { name, params: { '0': params.pathMatch } })
     let path = this.localePath(baseRoute, locale)
 
     // Handle different domains

--- a/src/plugins/routing.js
+++ b/src/plugins/routing.js
@@ -43,7 +43,9 @@ function switchLocalePathFactory (i18nPath) {
     if (!name) {
       return ''
     }
-    const baseRoute = Object.assign({}, this.$route , { name })
+
+		const { params, ...routeCopy } = this.$route
+		const baseRoute = Object.assign({}, routeCopy, { name, params: { '0': params.pathMatch } })
     let path = this.localePath(baseRoute, locale)
 
     // Handle different domains


### PR DESCRIPTION
Old version didn't create correct object for the `router.resolve` by Vue. 
Params should start with a 0 according to the Vue specs. Solved this issue by copying the route object and changing the params. Resulting in not creating warnings for each file and component being checked by Webpack. 

Solution:

Create a copy of the route by substracting the params element. Params element has a pathMatch value. If not this will result in undefined and Vue will handle this the correct way. Otherwise baseRoute will result in a valid url and won't start a warning. Other checks will remain the same. 

