### PR TITLE
Add canonical link to PREFIX_AND_DEFAULT duplicated pages

### DIFF
--- a/docs/seo.md
+++ b/docs/seo.md
@@ -5,6 +5,8 @@ By default, **nuxt-i18n** attempts to add some metadata to improve your pages SE
 * Add a _lang_ attribute containing current locale's ISO code to the `<html>` tag.
 * Generate `<link rel="alternate" hreflang="x">` tags for every language configured in `nuxt.config.js`. For each language, the ISO code is used as `hreflang` attribute's value. [More on hreflang](https://support.google.com/webmasters/answer/189077)
 * Generate `og:locale` and `og:locale:alternate` meta tags as defined in the [Open Graph protocol](http://ogp.me/#optional)
+* When using `prefix_and_default` strategy, generate `rel="canonical"` link on the default language routes containing the 
+prefix to avoid duplicate indexation. [More on canonical](https://support.google.com/webmasters/answer/182192#dup-content)
 
 
 For this feature to work, you must configure `locales` option as an array of objects, where each object has an `iso` option set to the language ISO code:

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ const {
   LOCALE_ISO_KEY,
   LOCALE_DOMAIN_KEY,
   LOCALE_FILE_KEY,
+  STRATEGIES,
   COMPONENT_OPTIONS_KEY
 } = require('./helpers/constants')
 
@@ -46,6 +47,7 @@ module.exports = function (userOptions) {
     LOCALE_ISO_KEY,
     LOCALE_DOMAIN_KEY,
     LOCALE_FILE_KEY,
+    STRATEGIES,
     COMPONENT_OPTIONS_KEY,
     getLocaleCodes,
     getLocaleFromRoute,

--- a/src/templates/seo-head.js
+++ b/src/templates/seo-head.js
@@ -17,9 +17,8 @@ export const nuxtI18nSeo = function () {
   // Prepare html lang attribute
   const currentLocaleData = this.$i18n.locales.find(l => l[LOCALE_CODE_KEY] === this.$i18n.locale)
   const htmlAttrs = {}
-  const currentLocaleIso = currentLocaleData && currentLocaleData[LOCALE_ISO_KEY]
-  if (currentLocaleIso) {
-    htmlAttrs.lang = currentLocaleIso
+  if (currentLocaleData && currentLocaleData[LOCALE_ISO_KEY]) {
+    htmlAttrs.lang = currentLocaleData[LOCALE_ISO_KEY]
   }
 
   // hreflang tags
@@ -41,18 +40,14 @@ export const nuxtI18nSeo = function () {
 
   // canonical links
   if (STRATEGY === '<%= options.STRATEGIES.PREFIX_AND_DEFAULT %>') {
-    if (currentLocaleIso) {
-      const canonicalPath = this.switchLocalePath(currentLocaleIso)
-      if (canonicalPath && canonicalPath !== this.$route.path) {
-        // Current page is not the canonical one -- add a canonical link
-        link.push({
-          hid: 'canonical-lang-' + currentLocaleIso,
-          rel: "canonical",
-          href: BASE_URL + canonicalPath
-        })
-      }
-    } else {
-      console.warn('[<%= options.MODULE_NAME %>] Locale ISO code is required to generate canonical link')
+    const canonicalPath = this.switchLocalePath(currentLocaleData[LOCALE_CODE_KEY])
+    if (canonicalPath && canonicalPath !== this.$route.path) {
+      // Current page is not the canonical one -- add a canonical link
+      link.push({
+        hid: 'canonical-lang-' + currentLocaleData[LOCALE_CODE_KEY],
+        rel: "canonical",
+        href: BASE_URL + canonicalPath
+      })
     }
   }
 

--- a/src/templates/seo-head.js
+++ b/src/templates/seo-head.js
@@ -12,12 +12,14 @@ export const nuxtI18nSeo = function () {
   const LOCALE_CODE_KEY = '<%= options.LOCALE_CODE_KEY %>'
   const LOCALE_ISO_KEY = '<%= options.LOCALE_ISO_KEY %>'
   const BASE_URL = '<%= options.baseUrl %>'
+  const STRATEGY = '<%= options.strategy %>'
 
   // Prepare html lang attribute
   const currentLocaleData = this.$i18n.locales.find(l => l[LOCALE_CODE_KEY] === this.$i18n.locale)
   const htmlAttrs = {}
-  if (currentLocaleData && currentLocaleData[LOCALE_ISO_KEY]) {
-    htmlAttrs.lang = currentLocaleData[LOCALE_ISO_KEY]
+  const currentLocaleIso = currentLocaleData && currentLocaleData[LOCALE_ISO_KEY]
+  if (currentLocaleIso) {
+    htmlAttrs.lang = currentLocaleIso
   }
 
   // hreflang tags
@@ -36,6 +38,23 @@ export const nuxtI18nSeo = function () {
       }
     })
     .filter(item => !!item)
+
+  // canonical links
+  if (STRATEGY === '<%= options.STRATEGIES.PREFIX_AND_DEFAULT %>') {
+    if (currentLocaleIso) {
+      const canonicalPath = this.switchLocalePath(currentLocaleIso)
+      if (canonicalPath && canonicalPath !== this.$route.path) {
+        // Current page is not the canonical one -- add a canonical link
+        link.push({
+          hid: 'canonical-lang-' + currentLocaleIso,
+          rel: "canonical",
+          href: BASE_URL + canonicalPath
+        })
+      }
+    } else {
+      console.warn('[<%= options.MODULE_NAME %>] Locale ISO code is required to generate canonical link')
+    }
+  }
 
   // og:locale meta
   const meta = []


### PR DESCRIPTION
When using `prefix_and_default` strategy, the default language pages have "duplicated routes". For example, if I have a route `A/B` with `en` as default language, I will get `/en/A/B` and `/A/B` routes.

For SEO, we needs, then, a `rel="canonical"` link.
This MR add on the `/en/A/B` route a canonical link to the `/A/B` route


More info: https://support.google.com/webmasters/answer/182192#dup-content




PS: I tried to add tests, but I've failed to setup tests on multiple nuxt.config.js files :/