### PR TITLE
Fixes #191: Add encodeURI option to allow skipping encodeURI for custom paths

### DIFF
--- a/docs/options-reference.md
+++ b/docs/options-reference.md
@@ -106,6 +106,12 @@ Here are all the options available when configuring the module and their default
   // the pages option, refer to the "Routing" section for usage
   pages: {},
 
+  // By default, custom paths will be encoded using encodeURI method.
+  // This does not work with regexp: "/foo/:slug-:id(\\d+)". If you want to use
+  // regexp in the path, then set this option to false, and make sure you process
+  // path encoding yourself.
+  encodeURI: true,
+
   // Called right before app's locale changes
   beforeLanguageSwitch: () => null,
 

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -175,31 +175,47 @@ You would need to set up your `pages` property as follows:
   pages: {
     about: {
       en: '/about',
-      fr: '/a-propos', 
+      fr: '/a-propos',
     },
     'services/index': {
       en: '/services',
-      fr: '/offres', 
+      fr: '/offres',
     },
     'services/development/index': {
       en: '/services/development',
-      fr: '/offres/developement', 
+      fr: '/offres/developement',
     },
     'services/development/app/index': {
       en: '/services/development/app',
-      fr: '/offres/developement/app', 
+      fr: '/offres/developement/app',
     },
     'services/development/website/index': {
       en: '/services/development/website',
-      fr: '/offres/developement/site-web', 
+      fr: '/offres/developement/site-web',
     },
     'services/coaching/index': {
       en: '/services/coaching',
-      fr: '/offres/formation', 
+      fr: '/offres/formation',
     }
   }
 }]
 ```
+
+### Regular Expression
+
+By default, all custom paths are encoded to handle non-latin characters in the path. This will convert paths with regular expression like `/foo/:slug-:id(\\d+)` to `/foo/:slug-:id(%5Cd+)`.
+
+If you would like to use regular expression in your custom paths, then you need to set the `encodeURI` option to false. Since no encoding will happen, you will have to make sure to pass in encoded paths yourself.
+
+```js
+// nuxt.config.js
+
+['nuxt-i18n', {
+  encodeURI: false
+}]
+```
+
+
 
 ## Ignore routes
 

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -216,7 +216,6 @@ If you would like to use regular expression in your custom paths, then you need 
 ```
 
 
-
 ## Ignore routes
 
 

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -51,6 +51,7 @@ exports.DEFAULT_OPTIONS = {
   },
   parsePages: true,
   pages: {},
+  encodeURI: true,
   beforeLanguageSwitch: () => null,
   onLanguageSwitched: () => null
 }

--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -11,6 +11,7 @@ exports.makeRoutes = (baseRoutes, {
   strategy,
   parsePages,
   pages,
+  encodeURI,
   pagesDir,
   differentDomains
 }) => {
@@ -77,7 +78,7 @@ exports.makeRoutes = (baseRoutes, {
 
       // Get custom path if any
       if (componentOptions.paths && componentOptions.paths[locale]) {
-        path = encodeURI(componentOptions.paths[locale])
+        path = encodeURI ? encodeURI(componentOptions.paths[locale]) : componentOptions.paths[locale]
       }
 
       // Add route prefix if needed


### PR DESCRIPTION
When a custom path has regular expression inside, encodeURI will escape special characters. `/foo/:slug-:id(\\d+)` will becomes `/foo/:slug-:id(%5Cd+)`.

This PR adds `encodeURI` option per the suggestion in #191. If it's set to false, then custom paths will not be encoded through `encodeURI` method. Since no encoding will happen, the user will need to ensure the correctly encoded paths are specified.