### PR TITLE
Update types

### DIFF
--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -1,6 +1,6 @@
 import Vue from "vue";
 import { RawLocation } from "vue-router";
-import VueI18n from "vue-i18n"
+import VueI18n from "vue-i18n";
 
 /**
  * The nuxt-i18n types namespace

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -12,3 +12,9 @@ declare module "vue/types/vue" {
     getRouteBaseName(route: RawLocation): string;
   }
 }
+
+declare module 'vue-i18n' {
+  interface IVueI18n {
+    locales: any
+  }
+}

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -9,9 +9,6 @@ declare namespace NuxtVueI18n {
   type Locale = VueI18n.Locale
 
   namespace Options {
-    // e.g.: ['en', 'fr', 'es']
-    type LocalesCodesArr = Locale[]
-
     // e.g.:
     // [
     //   { code: 'en', iso: 'en-US', file: 'en.js' },
@@ -46,7 +43,7 @@ declare namespace NuxtVueI18n {
 
     // special options for a "app.i18n" property: https://goo.gl/UwNfZo
     interface VueI18nInterface {
-      locales: LocalesCodesArr | LocaleObject[]
+      locales: Array<Locale | LocaleObject>
       defaultLocale: null | Locale
       differentDomains: boolean
       forwardedHost: boolean
@@ -54,7 +51,7 @@ declare namespace NuxtVueI18n {
       beforeLanguageSwitch: () => any
       onLanguageSwitched: () => any
     }
-    
+
     // see options reference: https://github.com/nuxt-community/nuxt-i18n/blob/master/docs/options-reference.md
     interface AllOptionsInterface extends VueI18nInterface {
       vueI18n: VueI18n.I18nOptions
@@ -95,7 +92,7 @@ declare module "vue/types/vue" {
 declare module "vue-i18n" {
   // the VueI18n class expands here: https://goo.gl/Xtp9EG
   // it is necessary for the $i18n property in Vue interface: "readonly $i18n: VueI18n & IVueI18n"
-  interface IVueI18n extends NuxtVueI18n.Options.AllOptionsInterface {
+  interface IVueI18n extends NuxtVueI18n.Options.VueI18nInterface {
 
   }
 }

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -83,6 +83,8 @@ declare module "vue/types/vue" {
     localePath(route: RawLocation, locale?: string): string;
     switchLocalePath(locale: string): string;
     getRouteBaseName(route: RawLocation): string;
+    // PHPStorm without this indicates that "$i18n" was not found.
+    readonly $i18n: VueI18n & IVueI18n;
   }
 }
 

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -1,10 +1,86 @@
-/**
- * Extends interfaces in Vue.js
- */
-
 import Vue from "vue";
 import { RawLocation } from "vue-router";
+import VueI18n from "vue-i18n"
 
+/**
+ * The nuxt-i18n types namespace
+ */
+declare namespace NuxtVueI18n {
+  type Locale = VueI18n.Locale
+
+  namespace Options {
+    // e.g.: ['en', 'fr', 'es']
+    type LocalesCodesArr = Locale[]
+
+    // e.g.:
+    // [
+    //   { code: 'en', iso: 'en-US', file: 'en.js' },
+    //   { code: 'fr', iso: 'fr-FR', file: 'fr.js' },
+    //   { code: 'es', iso: 'es-ES', file: 'es.js' }
+    // ]
+    interface LocaleObject {
+      code: Locale
+      // can be undefined: https://goo.gl/cCGKUV
+      iso?: string
+      // can be undefined: https://goo.gl/ryc5pF
+      file?: string
+      // Allow custom properties, e.g. "name": https://goo.gl/wrcb2G
+      [key: string]: any
+    }
+
+    interface DetectBrowserLanguageInterface {
+      useCookie: boolean
+      cookieKey: string
+      alwaysRedirect: boolean
+      fallbackLocale: Locale | null
+    }
+
+    interface Vuex {
+      moduleName: string
+      mutations: {
+        setLocale: string
+        setMessages: string
+      }
+      preserveState: boolean
+    }
+
+    // special options for a "app.i18n" property: https://goo.gl/UwNfZo
+    interface VueI18nInterface {
+      locales: LocalesCodesArr | LocaleObject[]
+      defaultLocale: null | Locale
+      differentDomains: boolean
+      forwardedHost: boolean
+      routesNameSeparator: string
+      beforeLanguageSwitch: () => any
+      onLanguageSwitched: () => any
+    }
+  }
+
+  // see options reference: https://github.com/nuxt-community/nuxt-i18n/blob/master/docs/options-reference.md
+  interface OptionsInterface extends Options.VueI18nInterface {
+    vueI18n: VueI18n.I18nOptions
+    strategy: "prefix_except_default" | "prefix" | "prefix_and_default"
+    lazy: boolean
+    langDir: string | null
+    rootRedirect: string | null
+    detectBrowserLanguage: Options.DetectBrowserLanguageInterface
+    seo: false
+    baseUrl: string
+    vuex: Options.Vuex
+    parsePages: boolean
+    // see https://goo.gl/NbzX3f
+    pages: {
+      [key: string]: boolean | {
+        [key: string]: boolean | string
+      }
+    }
+    encodePaths: boolean
+  }
+}
+
+/**
+ * Extends types in vue
+ */
 declare module "vue/types/vue" {
   interface Vue {
     localePath(route: RawLocation, locale?: string): string;
@@ -13,8 +89,13 @@ declare module "vue/types/vue" {
   }
 }
 
-declare module 'vue-i18n' {
-  interface IVueI18n {
-    locales: any
+/**
+ * Extends types in vue-i18n
+ */
+declare module "vue-i18n" {
+  // the VueI18n class expands here: https://goo.gl/Xtp9EG
+  // it is necessary for the $i18n property in Vue interface: "readonly $i18n: VueI18n & IVueI18n"
+  interface IVueI18n extends NuxtVueI18n.OptionsInterface {
+
   }
 }

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -54,27 +54,27 @@ declare namespace NuxtVueI18n {
       beforeLanguageSwitch: () => any
       onLanguageSwitched: () => any
     }
-  }
-
-  // see options reference: https://github.com/nuxt-community/nuxt-i18n/blob/master/docs/options-reference.md
-  interface OptionsInterface extends Options.VueI18nInterface {
-    vueI18n: VueI18n.I18nOptions
-    strategy: "prefix_except_default" | "prefix" | "prefix_and_default"
-    lazy: boolean
-    langDir: string | null
-    rootRedirect: string | null
-    detectBrowserLanguage: Options.DetectBrowserLanguageInterface
-    seo: false
-    baseUrl: string
-    vuex: Options.Vuex
-    parsePages: boolean
-    // see https://goo.gl/NbzX3f
-    pages: {
-      [key: string]: boolean | {
-        [key: string]: boolean | string
+    
+    // see options reference: https://github.com/nuxt-community/nuxt-i18n/blob/master/docs/options-reference.md
+    interface AllOptionsInterface extends VueI18nInterface {
+      vueI18n: VueI18n.I18nOptions
+      strategy: "prefix_except_default" | "prefix" | "prefix_and_default"
+      lazy: boolean
+      langDir: string | null
+      rootRedirect: string | null
+      detectBrowserLanguage: Options.DetectBrowserLanguageInterface
+      seo: false
+      baseUrl: string
+      vuex: Options.Vuex
+      parsePages: boolean
+      // see https://goo.gl/NbzX3f
+      pages: {
+        [key: string]: boolean | {
+          [key: string]: boolean | string
+        }
       }
+      encodePaths: boolean
     }
-    encodePaths: boolean
   }
 }
 
@@ -95,7 +95,7 @@ declare module "vue/types/vue" {
 declare module "vue-i18n" {
   // the VueI18n class expands here: https://goo.gl/Xtp9EG
   // it is necessary for the $i18n property in Vue interface: "readonly $i18n: VueI18n & IVueI18n"
-  interface IVueI18n extends NuxtVueI18n.OptionsInterface {
+  interface IVueI18n extends NuxtVueI18n.Options.AllOptionsInterface {
 
   }
 }


### PR DESCRIPTION
This code throws a error: 

> Property 'locales' does not exist on type 'VueI18n & IVueI18n'. Did you mean 'locale'?

```
get availableLocales () {
  return this.$i18n.locales.filter(i => i.code !== this.$i18n.locale)
}
```

It helps me.

Maybe this is not the best solution, but it should fix the error.

I think it's worth adding this for the rest of the variables:

https://github.com/nuxt-community/nuxt-i18n/blob/90bcd80e7f0cbf4f00d15353c4eadea31f6ff892/src/plugins/main.js#L53-L59