### PR TITLE
Fixes #221 store unsync when changing language in lazy 

### DIFF
--- a/src/templates/middleware.js
+++ b/src/templates/middleware.js
@@ -85,7 +85,7 @@ middleware['i18n'] = async ({ app, req, res, route, store, redirect, isHMR }) =>
       const messages = await loadLanguageAsync(app.i18n, newLocale)
       app.i18n.locale = newLocale
       app.i18n.onLanguageSwitched(oldLocale, newLocale)
-      syncVuex(locale, messages)
+      syncVuex(newLocale, messages)
     } else {
       // Lazy-loading disabled
       app.i18n.locale = newLocale


### PR DESCRIPTION
Fixes vues store unsync state when lazy i18n loading and you try to change language