### PR TITLE
Fix 'cannot read property "iso"' crash (issue #80)

### DIFF
--- a/src/templates/seo-head.js
+++ b/src/templates/seo-head.js
@@ -3,6 +3,7 @@ export const nuxtI18nSeo = function () {
   if (
     !this._hasMetaInfo ||
     !this.$i18n ||
+    !this.$i18n.locale ||
     !this.$i18n.locales ||
     this.$options[COMPONENT_OPTIONS_KEY] === false ||
     (this.$options[COMPONENT_OPTIONS_KEY] && this.$options[COMPONENT_OPTIONS_KEY].seo === false)


### PR DESCRIPTION
On visiting route that is not defined (404), and module's `defaultLocale`
is not defined (default), the code in main.js would set `app.i18n.locale`
to null and when the seo code would run, it would crash on trying to
access property `iso` of it. So don't allow seo code to run when locale
is not defined.