### PR TITLE
Always redirect to browser's language that was saved in cookie

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,8 +54,7 @@ module.exports = function (userOptions) {
     getForwarded,
     getHostname,
     getLocaleDomain,
-    syncVuex,
-    isSpa: this.options.mode === 'spa'
+    syncVuex
   }
 
   // Generate localized routes

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -83,6 +83,8 @@ declare module "vue/types/vue" {
     localePath(route: RawLocation, locale?: string): string;
     switchLocalePath(locale: string): string;
     getRouteBaseName(route: RawLocation): string;
+    getCookieLocale(): string | null;
+    setCookieLocale(locale: string): undefined;
     // PHPStorm without this indicates that "$i18n" was not found.
     readonly $i18n: VueI18n & IVueI18n;
   }


### PR DESCRIPTION
Make sure that after first visit, when we detect browser language and
store locale cookie, we reuse that cookie and re-set language during
navigation. Before this change, even with `alwaysRedirect` enabled, we
have only redirected on first visit and on next visits user got default
language again.

Changes:
  - Don't base ability to set client-side cookies on the `isSpa` flag.
    That flag signified whether app was in 'spa' mode (another possible
    mode is 'universal') and it only allowed setting client-side cookies
    in that mode. That's wrong as it should also be possible to set
    client-side cookies when running on client side in 'universal' mode.
    Use process.client and process.server instead, which are more
    appropriate flags to check for that purpose.
  - Expose setCookieLocale/getCookieLocale methods on `app.i18n` object
    as we need to be able to call setCookieLocale manually after changing
    language in the selector.