### PR TITLE
feat: Always redirect to language that was saved in cookie

### DIFF
--- a/docs/lang-switcher.md
+++ b/docs/lang-switcher.md
@@ -1,6 +1,6 @@
 # Lang Switcher
 
-When **nuxt-i18n** loads in your app, it adds your `locales` configuration to `app.$i18n`, which makes it really easy to display a lang switcher anywhere in your app.
+When **nuxt-i18n** loads in your app, it adds your `locales` configuration to `this.$i18n` (or `app.i18n`), which makes it really easy to display a lang switcher anywhere in your app.
 
 Here's an example lang switcher where a `name` key has been added to each locale object in order to display friendlier titles for each link:
 
@@ -39,3 +39,5 @@ computed: {
   ]
 }]
 ```
+
+If `detectBrowserLanguage.useCookie` and `detectBrowserLanguage.alwaysRedirect` options are enabled, you might want to persist change to locale by calling `this.$i18n.setLocaleCookie(locale)` (or `app.i18n.setLocaleCookie(locale)`) method. Otherwise locale will switch back to saved one during navigation.

--- a/src/index.js
+++ b/src/index.js
@@ -54,8 +54,7 @@ module.exports = function (userOptions) {
     getForwarded,
     getHostname,
     getLocaleDomain,
-    syncVuex,
-    isSpa: this.options.mode === 'spa'
+    syncVuex
   }
 
   // Generate localized routes

--- a/src/plugins/routing.js
+++ b/src/plugins/routing.js
@@ -112,9 +112,8 @@ Vue.mixin({
   }
 })
 
-
 export default ({ app, route }) => {
   app.localePath = localePathFactory('i18n', 'router')
-  app.switchLocalePath = switchLocalePathFactory('i18n'),
+  app.switchLocalePath = switchLocalePathFactory('i18n')
   app.getRouteBaseName = getRouteBaseNameFactory(route)
 }

--- a/src/templates/middleware.js
+++ b/src/templates/middleware.js
@@ -1,9 +1,9 @@
-import cookie from 'cookie'
-import Cookies from 'js-cookie'
+import Cookie from 'cookie'
+import JsCookie from 'js-cookie'
 import middleware from '../middleware'
 
 middleware['i18n'] = async (context) => {
-  const { app, req, res, route, store, redirect, isHMR } = context;
+  const { app, req, route, store, redirect, isHMR } = context;
 
   if (isHMR) {
     return
@@ -13,7 +13,6 @@ middleware['i18n'] = async (context) => {
   const lazy = <%= options.lazy %>
   const vuex = <%= JSON.stringify(options.vuex) %>
   const differentDomains = <%= options.differentDomains %>
-  const isSpa = <%= options.isSpa %>
 
   // Helpers
   const LOCALE_CODE_KEY = '<%= options.LOCALE_CODE_KEY %>'
@@ -23,7 +22,6 @@ middleware['i18n'] = async (context) => {
   const defaultLocaleRouteNameSuffix = '<%= options.defaultLocaleRouteNameSuffix %>'
   const locales = getLocaleCodes(<%= JSON.stringify(options.locales) %>)
   const syncVuex = <%= options.syncVuex %>
-
 
   let locale = app.i18n.locale || app.i18n.defaultLocale || null
 
@@ -38,33 +36,19 @@ middleware['i18n'] = async (context) => {
   const detectBrowserLanguage = <%= JSON.stringify(options.detectBrowserLanguage) %>
   const routeLocale = getLocaleFromRoute(route, routesNameSeparator, defaultLocaleRouteNameSuffix, locales)
 
-  const getCookie = () => {
-    if (isSpa) {
-      return Cookies.get(cookieKey);
-    } else if (req && typeof req.headers.cookie !== 'undefined') {
-      const cookies = req.headers && req.headers.cookie ? cookie.parse(req.headers.cookie) : {}
-      return cookies[cookieKey]
+  const { useCookie, cookieKey, alwaysRedirect, fallbackLocale } = detectBrowserLanguage
+
+  const getLocaleCookie = () => {
+    if (useCookie) {
+      if (process.client) {
+        return JsCookie.get(cookieKey);
+      } else if (req && typeof req.headers.cookie !== 'undefined') {
+        const cookies = req.headers && req.headers.cookie ? Cookie.parse(req.headers.cookie) : {}
+        return cookies[cookieKey]
+      }
     }
     return null
   }
-
-  const setCookie = (locale) => {
-    const date = new Date()
-    if (isSpa) {
-      Cookies.set(cookieKey, locale, {
-        expires: new Date(date.setDate(date.getDate() + 365)),
-        path: '/'
-      })
-    } else if (res) {
-      const redirectCookie = cookie.serialize(cookieKey, locale, {
-        expires: new Date(date.setDate(date.getDate() + 365)),
-        path: '/'
-      })
-      res.setHeader('Set-Cookie', redirectCookie)
-    }
-  }
-
-  const { useCookie, cookieKey, alwaysRedirect, fallbackLocale } = detectBrowserLanguage
 
   const switchLocale = async (newLocale) => {
     // Abort if different domains option enabled
@@ -79,8 +63,8 @@ middleware['i18n'] = async (context) => {
 
     const oldLocale = app.i18n.locale
     app.i18n.beforeLanguageSwitch(oldLocale, newLocale)
-    if(useCookie) {
-      setCookie(newLocale)
+    if (useCookie) {
+      app.i18n.setLocaleCookie(newLocale)
     }
     // Lazy-loading enabled
     if (lazy) {
@@ -100,11 +84,11 @@ middleware['i18n'] = async (context) => {
   if (detectBrowserLanguage) {
     let browserLocale
 
-    if (useCookie && (browserLocale = getCookie()) && browserLocale !== 1 && browserLocale !== '1') {
+    if (useCookie && (browserLocale = getLocaleCookie()) && browserLocale !== 1 && browserLocale !== '1') {
       // Get preferred language from cookie if present and enabled
       // Exclude 1 for backwards compatibility and fallback when fallbackLocale is empty
-    } else if (isSpa && typeof navigator !== 'undefined' && navigator.language) {
-      // Get browser language either from navigator if running in mode SPA, or from the headers
+    } else if (process.client && typeof navigator !== 'undefined' && navigator.language) {
+      // Get browser language either from navigator if running on client side, or from the headers
       browserLocale = navigator.language.toLocaleLowerCase().substring(0, 2)
     } else if (req && typeof req.headers['accept-language'] !== 'undefined') {
       browserLocale = req.headers['accept-language'].split(',')[0].toLocaleLowerCase().substring(0, 2)
@@ -112,23 +96,26 @@ middleware['i18n'] = async (context) => {
 
     if (browserLocale) {
       // Handle cookie option to prevent multiple redirections
-      if(!useCookie || alwaysRedirect || !getCookie()) {
+      if (!useCookie || alwaysRedirect || !getLocaleCookie()) {
         const routeName = route && route.name ? app.getRouteBaseName(route) : 'index'
         let redirectToLocale = fallbackLocale
 
         // Use browserLocale if we support it, otherwise use fallbackLocale
-        if(locales.indexOf(browserLocale) !== -1) {
+        if (locales.includes(browserLocale)) {
           redirectToLocale = browserLocale
         }
 
-        if (redirectToLocale && redirectToLocale !== app.i18n.locale && locales.indexOf(redirectToLocale) !== -1) {
+        if (redirectToLocale && locales.includes(redirectToLocale)) {
+          if (redirectToLocale !== app.i18n.locale) {
+            // We switch the locale before redirect to prevent loops
+            await switchLocale(redirectToLocale)
 
-          // We switch the locale before redirect to prevent loops
-          await switchLocale(redirectToLocale)
-
-          redirect(app.localePath(Object.assign({}, route , {
-            name: routeName
-          }), redirectToLocale))
+            redirect(app.localePath(Object.assign({}, route , {
+              name: routeName
+            }), redirectToLocale))
+          } else if (useCookie && !getLocaleCookie()) {
+            app.i18n.setLocaleCookie(redirectToLocale)
+          }
 
           return
         }

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -50,6 +50,7 @@ declare namespace NuxtVueI18n {
       routesNameSeparator: string
       beforeLanguageSwitch: () => any
       onLanguageSwitched: () => any
+      setLocaleCookie: (locale: string) => undefined
     }
 
     // see options reference: https://github.com/nuxt-community/nuxt-i18n/blob/master/docs/options-reference.md


### PR DESCRIPTION
Make sure that after first visit, when we detect browser language and
store locale cookie, we reuse that cookie and re-set language during
navigation. Before this change, even with `alwaysRedirect` enabled, we
have only redirected on first visit and on next visits user got default
language again.

Changes:
  - Don't base ability to set client-side cookies on the `isSpa` flag.
    That flag signified whether app was in 'spa' mode (another possible
    mode is 'universal') and it only allowed setting client-side cookies
    in that mode. That's wrong as it should also be possible to set
    client-side cookies when running on client side in 'universal' mode.
    Use `process.client` and `process.server` instead, which are more
    appropriate flags to check for that purpose.
  - Expose setLocaleCookie on `app.i18n` (`this.$i18n` in components)
    as we need to be able to call it manually after changing locale
    in custom language selector.