### PR TITLE
Load fallback locale when needed if lazy-loading (fixes #34)

### DIFF
--- a/docs/lazy-load-translations.md
+++ b/docs/lazy-load-translations.md
@@ -7,8 +7,8 @@ To enable translations lazy-loading, follow these 4 steps when configuring **nux
 * Set `lazy` option to `true`
 * Set `langDir` option to the directory that contains your translation files (this can NOT be empty)
 * Configure `locales` option as an array of object, where each object has a `file` key which value is the translation file corresponding to the locale
-* Optionnaly, remove all messages that you might have passed to vue-i18n via `vueI18n` option
-* Each `file` can return either an `Object` or a `function` (Supports `Promises`)
+* Optionally, remove all messages that you might have passed to vue-i18n via `vueI18n` option
+* Each `file` can return either an `Object` or a `function` (supports `Promises`)
 
 Example files structure:
 

--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -115,6 +115,12 @@ export default async (context) => {
   // Lazy-load translations
   if (lazy) {
     const { loadLanguageAsync } = require('./utils')
+
+    // Load fallback locale.
+    if (app.i18n.fallbackLocale && app.i18n.locale !== app.i18n.fallbackLocale) {
+      await loadLanguageAsync(context, app.i18n.fallbackLocale)
+    }
+
     const messages = await loadLanguageAsync(context, app.i18n.locale)
     syncVuex(locale, messages)
     return messages


### PR DESCRIPTION
Fallback locale is needed to properly handle strings that exist in
base/fallback locale but not in currently used one.

Fix from @orblazer