### PR TITLE
Fix exception when using multiple domains option (fixes #293)

### DIFF
--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -7,7 +7,7 @@ import { nuxtI18nSeo } from './seo-head'
 Vue.use(VueI18n)
 
 export default async (context) => {
-  const { app, route, store, res } = context;
+  const { app, route, store, req, res } = context;
 
   // Options
   const lazy = <%= options.lazy %>


### PR DESCRIPTION
Even though `req` doesn't seem used in the file, it is added after
templates are filled in.