### PR TITLE
fix: add missing vue-template-compiler dependency (fixes #297)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "cookie": "^0.3.1",
     "js-cookie": "^2.2.0",
     "vue-i18n": "^8.11.2",
-    "vue-i18n-extensions": "^0.2.1"
+    "vue-i18n-extensions": "^0.2.1",
+    "vue-template-compiler": "^2.6.10"
   },
   "devDependencies": {
     "@babel/runtime": "7.4.4",

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,6 @@ const {
   COMPONENT_OPTIONS_KEY
 } = require('./helpers/constants')
 
-const { makeRoutes } = require('./helpers/routes')
 const {
   getLocaleCodes,
   getLocaleFromRoute,
@@ -60,6 +59,8 @@ module.exports = function (userOptions) {
   // Generate localized routes
   const pagesDir = this.options.dir && this.options.dir.pages ? this.options.dir.pages : 'pages'
   this.extendRoutes((routes) => {
+    const { makeRoutes } = require('./helpers/routes')
+
     const localizedRoutes = makeRoutes(routes, {
       ...options,
       pagesDir


### PR DESCRIPTION
Also only require makeRoutes when actually building app.

fixes #297.