### PR TITLE
fix: remove explicit dependency on vue-template-compiler (fixes #297)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
     "cookie": "^0.3.1",
     "js-cookie": "^2.2.0",
     "vue-i18n": "^8.11.2",
-    "vue-i18n-extensions": "^0.2.1",
-    "vue-template-compiler": "^2.6.10"
+    "vue-i18n-extensions": "^0.2.1"
   },
   "devDependencies": {
     "@babel/runtime": "7.4.4",

--- a/src/helpers/components.js
+++ b/src/helpers/components.js
@@ -3,6 +3,8 @@ const { COMPONENT_OPTIONS_KEY } = require('./constants')
 
 const acorn = require('acorn')
 const walker = require('acorn-walk')
+// Must not be an explicit dependency to avoid version mismatch issue.
+// See https://github.com/nuxt-community/nuxt-i18n/issues/297
 const compiler = require('vue-template-compiler')
 
 exports.extractComponentOptions = (path) => {

--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,9 @@ module.exports = function (userOptions) {
   // Generate localized routes
   const pagesDir = this.options.dir && this.options.dir.pages ? this.options.dir.pages : 'pages'
   this.extendRoutes((routes) => {
+    // This import (or more specifically 'vue-template-compiler' in helpers/components.js) needs to
+    // be required only at build time to avoid problems when 'vue-template-compiler' dependency is
+    // not available (at runtime, when using nuxt-start).
     const { makeRoutes } = require('./helpers/routes')
 
     const localizedRoutes = makeRoutes(routes, {


### PR DESCRIPTION
We can't have explicit dependency as that package requires its and vue's
versions to match exactly and we can't ensure that. Remove it and just
make sure that this dependency is only used on building nuxt app (done
before already, just added more explanation in comments).