### PR TITLE
fix: do not discard already present set-cookie header

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "acorn": "^6.1.1",
     "acorn-dynamic-import": "^4.0.0",
     "acorn-walk": "^6.1.1",
-    "cookie": "^0.4.0",
+    "cookies": "^0.7.3",
     "is-https": "^1.0.0",
     "js-cookie": "^2.2.0",
     "vue-i18n": "^8.11.2",

--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -1,4 +1,4 @@
-import Cookie from 'cookie'
+import Cookies from 'cookies'
 import JsCookie from 'js-cookie'
 import Vue from 'vue'
 import VueI18n from 'vue-i18n'
@@ -66,11 +66,12 @@ export default async (context) => {
         path: '/'
       })
     } else if (res) {
-      const redirectCookie = Cookie.serialize(cookieKey, locale, {
+      const cookies = new Cookies(req, res)
+      cookies.set(cookieKey, locale, {
         expires: new Date(date.setDate(date.getDate() + 365)),
-        path: '/'
+        path: '/',
+        httpOnly: false
       })
-      res.setHeader('Set-Cookie', redirectCookie)
     }
   }
 

--- a/src/templates/middleware.js
+++ b/src/templates/middleware.js
@@ -1,9 +1,9 @@
-import Cookie from 'cookie'
+import Cookies from 'cookies'
 import JsCookie from 'js-cookie'
 import middleware from '../middleware'
 
 middleware['i18n'] = async (context) => {
-  const { app, req, route, store, redirect, isHMR } = context;
+  const { app, req, res, route, store, redirect, isHMR } = context;
 
   if (isHMR) {
     return
@@ -43,8 +43,8 @@ middleware['i18n'] = async (context) => {
       if (process.client) {
         return JsCookie.get(cookieKey);
       } else if (req && typeof req.headers.cookie !== 'undefined') {
-        const cookies = req.headers && req.headers.cookie ? Cookie.parse(req.headers.cookie) : {}
-        return cookies[cookieKey]
+        const cookies = new Cookies(req, res)
+        return cookies.get(cookieKey)
       }
     }
     return null

--- a/yarn.lock
+++ b/yarn.lock
@@ -3079,7 +3079,7 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
 
-cookie@0.4.0, cookie@^0.4.0:
+cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
@@ -3088,6 +3088,14 @@ cookie@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
   integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
+
+cookies@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/cookies/-/cookies-0.7.3.tgz#7912ce21fbf2e8c2da70cf1c3f351aecf59dadfa"
+  integrity sha512-+gixgxYSgQLTaTIilDHAdlNPZDENDQernEMiIcZpYYP14zgHsCt4Ce1FEjFtcp6GefhozebB6orvhAAWx/IS0A==
+  dependencies:
+    depd "~1.1.2"
+    keygrip "~1.0.3"
 
 copy-concurrently@^1.0.0:
   version "1.0.5"
@@ -6361,6 +6369,11 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+keygrip@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.0.3.tgz#399d709f0aed2bab0a059e0cdd3a5023a053e1dc"
+  integrity sha512-/PpesirAIfaklxUzp4Yb7xBper9MwP6hNRA6BGGUFCgbJ+BM5CKBtsoxinNXkLHAr+GXS1/lSlF2rP7cv5Fl+g==
 
 killable@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This PR aims at fixing the current behavior of `nuxt-i18n` when setting the detected language cookie.
If someone were to set a cookie within a Nuxt server-middleware (e.g. a CSRF token cookie), it will be discarded only the first time `nuxt-i18n` is setting the language redirection cookie.

The root cause comes from using `res.setHeader('Set-Cookie', redirectCookie)`: it no longer implicitly append the cookie value to the current list of `Set-Cookie` values in Express > 4, as explained here: https://github.com/expressjs/express/wiki/Migrating-from-3.x-to-4.x#ressetheaderset-cookie-val

To keep compatibility of this middleware with requests/responses from Express/Connect/etc., using the `cookies` package instead of `cookie` seems like a sensible choice to me, and fixes nicely the issue.

If I missed something while refactoring the code, please let me know so we can find the most elegant and robust solution.