### PR TITLE
Only require is-https dependency on the server

### DIFF
--- a/src/plugins/routing.js
+++ b/src/plugins/routing.js
@@ -1,6 +1,5 @@
 import './middleware'
 import Vue from 'vue'
-import isHTTPS from 'is-https'
 
 const routesNameSeparator = '<%= options.routesNameSeparator %>'
 
@@ -75,6 +74,7 @@ function switchLocalePathFactory (i18nPath) {
       if (lang && lang[LOCALE_DOMAIN_KEY]) {
         let protocol
         if (process.server) {
+          const isHTTPS = require('is-https');
           const { req } = this.$options._parentVnode.ssrContext
           protocol = isHTTPS(req) ? 'https' : 'http'
         } else {


### PR DESCRIPTION
Makes that dependency be tree-shaken and not included at all on the
client. As a side effect, fixes IE11 that had problem with JS default
arguments used in is-https package.