### PR TITLE
fix: Move SEO types out of Vue module declaration

### DIFF
--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -76,27 +76,28 @@ declare namespace NuxtVueI18n {
   }
 }
 
+interface NuxtI18nSeo {
+  htmlAttrs?: {
+    lang?: string
+  }
+  link?: {
+    hid: string,
+    rel: string,
+    href: string,
+    hreflang: string
+  }[]
+  meta?: {
+    hid: string,
+    name: string,
+    property: string,
+    content: string
+  }[]
+}
+
 /**
  * Extends types in vue
  */
 declare module "vue/types/vue" {
-  interface NuxtI18nSeo {
-    htmlAttrs?: {
-      lang?: string
-    }
-    link?: {
-      hid: string,
-      rel: string,
-      href: string,
-      hreflang: string
-    }[]
-    meta?: {
-      hid: string,
-      name: string,
-      property: string,
-      content: string
-    }[]
-  }
   interface Vue {
     localePath(route: RawLocation, locale?: string): string;
     switchLocalePath(locale: string): string;


### PR DESCRIPTION
This follows up on the discussion here: https://github.com/nuxt-community/nuxt-i18n/pull/319#discussion_r289303554

> rchl 22 days ago  Member
> I don't really know much about typescript or writing declaration files but should this interface be defined outside of the declare module block?
> 
> kevinmarrec 20 days ago  Member
> @rchl Is right, the interface definition should be before declaring module and not inside.