### PR TITLE
Use default locale's custom path if not defined for a locale

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -201,6 +201,8 @@ You would need to set up your `pages` property as follows:
 }]
 ```
 
+If a custom path is missing for one of the locales, the `defaultLocale` custom path is used, if set.
+
 ### Regular Expression
 
 By default, all custom paths are encoded to handle non-latin characters in the path. This will convert paths with regular expression like `/foo/:slug-:id(\\d+)` to `/foo/:slug-:id(%5Cd+)`.

--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -27,7 +27,7 @@ exports.makeRoutes = (baseRoutes, {
     if (parsePages) {
       pageOptions = extractComponentOptions(route.component)
     } else {
-      pageOptions = getPageOptions(route, pages, locales, pagesDir)
+      pageOptions = getPageOptions(route, pages, locales, pagesDir, defaultLocale)
     }
 
     // Skip route if i18n is disabled on page

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -53,7 +53,7 @@ exports.getPageOptions = (route, pages, locales, pagesDir, defaultLocale) => {
   options.locales = options.locales.filter(locale => pageOptions[locale] !== false)
 
   // Construct paths object
-  options.paths = options.locales
+  options.locales
     .forEach(locale => {
       if (typeof pageOptions[locale] === 'string') {
         // Set custom path if any

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -25,13 +25,14 @@ exports.getLocaleCodes = getLocaleCodes
 
 /**
  * Retrieve page's options from the module's configuration for a given route
- * @param  {Object} route    Route
- * @param  {Object} pages    Pages options from module's configuration
- * @param  {Array} locales   Locale from module's configuration
- * @param  {String} pagesDir Pages dir from Nuxt's configuration
- * @return {Object}          Page options
+ * @param  {Object} route         Route
+ * @param  {Object} pages         Pages options from module's configuration
+ * @param  {Array} locales        Locale from module's configuration
+ * @param  {String} pagesDir      Pages dir from Nuxt's configuration
+ * @param  {String} defaultLocale Default locale from Nuxt's configuration
+ * @return {Object}               Page options
  */
-exports.getPageOptions = (route, pages, locales, pagesDir) => {
+exports.getPageOptions = (route, pages, locales, pagesDir, defaultLocale) => {
   const options = {
     locales: getLocaleCodes(locales),
     paths: {}
@@ -47,16 +48,22 @@ exports.getPageOptions = (route, pages, locales, pagesDir) => {
   if (!pageOptions) {
     return options
   }
-  // Construct options object
-  Object.keys(pageOptions).forEach((locale) => {
-    // Remove disabled locales from page options
-    if (pageOptions[locale] === false) {
-      options.locales = options.locales.filter(l => l !== locale)
-    } else if (typeof pageOptions[locale] === 'string') {
-      // Set custom path if any
-      options.paths[locale] = pageOptions[locale]
-    }
-  })
+
+  // Remove disabled locales from page options
+  options.locales = options.locales.filter(locale => pageOptions[locale] !== false)
+
+  // Construct paths object
+  options.paths = options.locales
+    .forEach(locale => {
+      if (typeof pageOptions[locale] === 'string') {
+        // Set custom path if any
+        options.paths[locale] = pageOptions[locale]
+      } else if (typeof pageOptions[defaultLocale] === 'string') {
+        // Set default locale's custom path if any
+        options.paths[locale] = pageOptions[defaultLocale]
+      }
+    })
+
   return options
 }
 


### PR DESCRIPTION
Hello,

Here is a PR to use default locale's custom path when a custom path is not defined for a locale.
It can help if you have a lot of locales to manage and only want a custom path for a few of them.