### PR TITLE
(fix): localePath in hashmode

### DIFF
--- a/src/plugins/routing.js
+++ b/src/plugins/routing.js
@@ -37,16 +37,8 @@ function localePathFactory (i18nPath, routerPath) {
 
     // Resolve localized route
     const router = this[routerPath]
-    const resolved = router.resolve(localizedRoute)
-    let { href } = resolved
-
-    // Remove baseUrl from href (will be added back by nuxt-link)
-    if (router.options.base) {
-      const regexp = new RegExp(router.options.base)
-      href = href.replace(regexp, '/')
-    }
-
-    return href
+    const { route: { fullPath } } = router.resolve(localizedRoute)
+    return fullPath
   }
 }
 

--- a/test/fixtures/basic/module.test.js
+++ b/test/fixtures/basic/module.test.js
@@ -103,4 +103,34 @@ describe('basic', () => {
     const html = await get('/fr/imbrication-dynamique/1/2/3')
     expect(cleanUpScripts(html)).toMatchSnapshot()
   })
+
+  test('localePath returns correct path', async () => {
+    const window = await nuxt.renderAndGetWindow(url('/'))
+    const newRoute = window.$nuxt.localePath('about')
+    expect(newRoute).toBe('/about-us')
+  })
+})
+
+describe('hash mode', () => {
+  let nuxt
+
+  beforeAll(async () => {
+    config.router = {
+      mode: 'hash'
+    }
+
+    nuxt = new Nuxt(config)
+    await new Builder(nuxt).build()
+    await nuxt.listen(process.env.PORT)
+  })
+
+  afterAll(async () => {
+    await nuxt.close()
+  })
+
+  test('localePath returns correct path (without hash)', async () => {
+    const window = await nuxt.renderAndGetWindow(url('/'))
+    const newRoute = window.$nuxt.localePath('about')
+    expect(newRoute).toBe('/about-us')
+  })
 })

--- a/test/fixtures/basic/module.test.js
+++ b/test/fixtures/basic/module.test.js
@@ -134,3 +134,27 @@ describe('hash mode', () => {
     expect(newRoute).toBe('/about-us')
   })
 })
+
+describe('with router base', () => {
+  let nuxt
+
+  beforeAll(async () => {
+    config.router = {
+      base: '/app/'
+    }
+
+    nuxt = new Nuxt(config)
+    await new Builder(nuxt).build()
+    await nuxt.listen(process.env.PORT)
+  })
+
+  afterAll(async () => {
+    await nuxt.close()
+  })
+
+  test('localePath returns correct path', async () => {
+    const window = await nuxt.renderAndGetWindow(url('/app/'))
+    const newRoute = window.$nuxt.localePath('about')
+    expect(newRoute).toBe('/about-us')
+  })
+})


### PR DESCRIPTION
### What problem does this feature solve?

When using Nuxt's router in [hash mode](https://nuxtjs.org/api/configuration-router#mode) `localePath` returns a string containing a hash which breaks the router functionality.

#### Replication:
https://codesandbox.io/s/nuxt-i18n-localepath-hash-mode-5xfz4

Both the _About_ button on the [homepage](https://5xfz4.sse.codesandbox.io/#/) and the _Back home_ button on the [about page](https://5xfz4.sse.codesandbox.io/#/about) do not resolve.

### What does the proposed changes look like?
Vue-Router seems to work when you provide a string of a route without a hash in front.

Make `localePath` return the resolved routes `route.fullPath` instead of the `href`. `route.fullPath` does not include the starting hash character.

I added a few extra tests to specifically test for these conditions. Because `jsdom`, used by Nuxt's `renderAndGetWindow` does not allow navigation, I could not provide any validation after a programmatic router.push. I could only provide testing for the returned localized route.

At this time I cannot find breaking changes caused by this PR. 

I happily await your feedback.