### PR TITLE
refactor: Disable setLocale & setMessages mutations by default

### DIFF
--- a/docs/options-reference.md
+++ b/docs/options-reference.md
@@ -93,14 +93,14 @@ Here are all the options available when configuring the module and their default
 
     // Mutations config
     mutations: {
-      // Mutation to commit to store current locale, set to false to disable
-      setLocale: 'I18N_SET_LOCALE',
+      // If enabled, current app's locale is synced with nuxt-i18n store module
+      setLocale: false,
 
-      // Mutation to commit to store current message, set to false to disable
-      setMessages: 'I18N_SET_MESSAGES',
+      // If enabled, current translation messages are synced with nuxt-i18n store module
+      setMessages: false,
 
       // Mutation to commit to set route parameters translations
-      setRouteParams: 'I18N_SET_ROUTE_PARAMS'
+      setRouteParams: true
     }
   },
 

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -45,9 +45,9 @@ exports.DEFAULT_OPTIONS = {
   vuex: {
     moduleName: 'i18n',
     mutations: {
-      setLocale: 'I18N_SET_LOCALE',
-      setMessages: 'I18N_SET_MESSAGES',
-      setRouteParams: 'I18N_SET_ROUTE_PARAMS'
+      setLocale: false,
+      setMessages: false,
+      setRouteParams: true
     }
   },
   parsePages: true,

--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -30,37 +30,47 @@ export default async (context) => {
     store.registerModule(vuex.moduleName, {
       namespaced: true,
       state: () => ({
-        locale: '',
-        messages: {},
-        routeParams: {}
+        <% if (options.vuex.mutations.setLocale) { %>locale: '',<% } %>
+        <% if (options.vuex.mutations.setMessages) { %>messages: {},<% } %>
+        <% if (options.vuex.mutations.setRouteParams) { %>routeParams: {}<% } %>
       }),
       actions: {
+        <% if (options.vuex.mutations.setLocale) { %>
         setLocale ({ commit }, locale) {
-          commit(vuex.mutations.setLocale, locale)
+          commit('setLocale', locale)
         },
+        <% } if (options.vuex.mutations.setMessages) { %>
         setMessages ({ commit }, messages) {
-          commit(vuex.mutations.setMessages, messages)
+          commit('setMessages', messages)
         },
+        <% } if (options.vuex.mutations.setRouteParams) { %>
         setRouteParams ({ commit }, params) {
           if (process.env.NODE_ENV === 'development') {
             validateRouteParams(params)
           }
-          commit(vuex.mutations.setRouteParams, params)
+          commit('setRouteParams', params)
         }
+        <% } %>
       },
       mutations: {
-        [vuex.mutations.setLocale] (state, locale) {
+        <% if (options.vuex.mutations.setLocale) { %>
+          setLocale (state, locale) {
           state.locale = locale
         },
-        [vuex.mutations.setMessages] (state, messages) {
+        <% } if (options.vuex.mutations.setMessages) { %>
+        setMessages (state, messages) {
           state.messages = messages
         },
-        [vuex.mutations.setRouteParams] (state, params) {
+        <% } if (options.vuex.mutations.setRouteParams) { %>
+        setRouteParams (state, params) {
           state.routeParams = params
         }
+        <% } %>
       },
       getters: {
+        <% if (options.vuex.mutations.setRouteParams) { %>
         localeRouteParams: ({ routeParams }) => locale => routeParams[locale] || {}
+        <% } %>
       }
     }, { preserveState: !!store.state[vuex.moduleName] })
   }


### PR DESCRIPTION
BREAKING CHANGE: The mutations responsible for syncing nuxt-i18n's store module with vue-i18n's
locale and messages are now disabled by default, you'll need to manually re-enable them in the
module's configuration