### PR TITLE
refactor: Rename and flatten vuex options

### DIFF
--- a/docs/options-reference.md
+++ b/docs/options-reference.md
@@ -91,17 +91,14 @@ Here are all the options available when configuring the module and their default
     // Module namespace
     moduleName: 'i18n',
 
-    // Mutations config
-    mutations: {
-      // If enabled, current app's locale is synced with nuxt-i18n store module
-      setLocale: false,
+    // If enabled, current app's locale is synced with nuxt-i18n store module
+    syncLocale: false,
 
-      // If enabled, current translation messages are synced with nuxt-i18n store module
-      setMessages: false,
+    // If enabled, current translation messages are synced with nuxt-i18n store module
+    syncMessages: false,
 
-      // Mutation to commit to set route parameters translations
-      setRouteParams: true
-    }
+    // Mutation to commit to set route parameters translations
+    syncRouteParams: true
   },
 
   // By default, custom routes are extracted from page files using acorn parsing,

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -44,11 +44,9 @@ exports.DEFAULT_OPTIONS = {
   baseUrl: '',
   vuex: {
     moduleName: 'i18n',
-    mutations: {
-      setLocale: false,
-      setMessages: false,
-      setRouteParams: true
-    }
+    syncLocale: false,
+    syncMessages: false,
+    syncRouteParams: true
   },
   parsePages: true,
   pages: {},

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -142,10 +142,10 @@ exports.getLocaleDomain = () => {
  */
 exports.syncVuex = async (locale = null, messages = null) => {
   if (vuex && store) {
-    if (locale !== null && vuex.mutations.setLocale) {
+    if (locale !== null && vuex.syncLocale) {
       await store.dispatch(vuex.moduleName + '/setLocale', locale)
     }
-    if (messages !== null && vuex.mutations.setMessages) {
+    if (messages !== null && vuex.syncMessages) {
       await store.dispatch(vuex.moduleName + '/setMessages', messages)
     }
   }

--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -30,20 +30,20 @@ export default async (context) => {
     store.registerModule(vuex.moduleName, {
       namespaced: true,
       state: () => ({
-        <% if (options.vuex.mutations.setLocale) { %>locale: '',<% } %>
-        <% if (options.vuex.mutations.setMessages) { %>messages: {},<% } %>
-        <% if (options.vuex.mutations.setRouteParams) { %>routeParams: {}<% } %>
+        <% if (options.vuex.syncLocale) { %>locale: '',<% } %>
+        <% if (options.vuex.syncMessages) { %>messages: {},<% } %>
+        <% if (options.vuex.syncRouteParams) { %>routeParams: {}<% } %>
       }),
       actions: {
-        <% if (options.vuex.mutations.setLocale) { %>
+        <% if (options.vuex.syncLocale) { %>
         setLocale ({ commit }, locale) {
           commit('setLocale', locale)
         },
-        <% } if (options.vuex.mutations.setMessages) { %>
+        <% } if (options.vuex.syncMessages) { %>
         setMessages ({ commit }, messages) {
           commit('setMessages', messages)
         },
-        <% } if (options.vuex.mutations.setRouteParams) { %>
+        <% } if (options.vuex.syncRouteParams) { %>
         setRouteParams ({ commit }, params) {
           if (process.env.NODE_ENV === 'development') {
             validateRouteParams(params)
@@ -53,22 +53,22 @@ export default async (context) => {
         <% } %>
       },
       mutations: {
-        <% if (options.vuex.mutations.setLocale) { %>
+        <% if (options.vuex.syncLocale) { %>
           setLocale (state, locale) {
           state.locale = locale
         },
-        <% } if (options.vuex.mutations.setMessages) { %>
+        <% } if (options.vuex.syncMessages) { %>
         setMessages (state, messages) {
           state.messages = messages
         },
-        <% } if (options.vuex.mutations.setRouteParams) { %>
+        <% } if (options.vuex.syncRouteParams) { %>
         setRouteParams (state, params) {
           state.routeParams = params
         }
         <% } %>
       },
       getters: {
-        <% if (options.vuex.mutations.setRouteParams) { %>
+        <% if (options.vuex.syncRouteParams) { %>
         localeRouteParams: ({ routeParams }) => locale => routeParams[locale] || {}
         <% } %>
       }


### PR DESCRIPTION
- `vuex.mutations.setLocale` has been renamed to `vuex.syncLocale`
- `vuex.mutations.setMessages` has been renamed to `vuex.syncMessages`

BREAKING CHANGE: Store module's options have been flattened and renamed