### PR TITLE
Add description of iso code to documents

### DIFF
--- a/docs/options-reference.md
+++ b/docs/options-reference.md
@@ -18,9 +18,9 @@ Here are all the options available when configuring the module and their default
   //   { code: 'fr', iso: 'fr-FR', file: 'fr.js' },
   //   { code: 'es', iso: 'es-ES', file: 'es.js' }
   // ]
-  //   `iso` value should have:
-  //   - code of ISO 639-1
-  //   - code of ISO 639-1 and code of ISO 3166-1 alpha-2, with a hyphen
+  //   `iso` value should have either:
+  //   - code of ISO 639-1 (e.g. 'en')
+  //   - code of ISO 639-1 and code of ISO 3166-1 alpha-2, with a hyphen (e.g. 'en-US')
   locales: [],
 
   // The app's default locale, URLs for this locale won't have a prefix if

--- a/docs/options-reference.md
+++ b/docs/options-reference.md
@@ -20,7 +20,7 @@ Here are all the options available when configuring the module and their default
   // ]
   //   `iso` value should have:
   //   - code of ISO 639-1
-  //   - code of ISO 639-1 and code of ISO 3166-1 alpha-2 with a hyphen
+  //   - code of ISO 639-1 and code of ISO 3166-1 alpha-2, with a hyphen
   locales: [],
 
   // The app's default locale, URLs for this locale won't have a prefix if

--- a/docs/options-reference.md
+++ b/docs/options-reference.md
@@ -18,6 +18,9 @@ Here are all the options available when configuring the module and their default
   //   { code: 'fr', iso: 'fr-FR', file: 'fr.js' },
   //   { code: 'es', iso: 'es-ES', file: 'es.js' }
   // ]
+  //   `iso` value should have:
+  //   - code of ISO 639-1
+  //   - code of ISO 639-1 and code of ISO 3166-1 alpha-2 with a hyphen
   locales: [],
 
   // The app's default locale, URLs for this locale won't have a prefix if


### PR DESCRIPTION
I think that documents should show clearly what kind of value to use for `iso` of options.
So, I've add description of iso code to documents as comment of source code.