### PR TITLE
docs: Add link to discord and add info about types configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ yarn docs:dev
 
 ## Issues, questions & requests
 
-Please use [CMTY](https://cmty.app/nuxt/nuxt-i18n/issues?type=question) for any question you might have.
+Please use [Discord](https://discord.nuxtjs.org/) for any question you might have.
 
 
 ## License

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -28,5 +28,13 @@ Then add the module to `nuxt.config.js`:
 }
 ```
 
+If using typescript or running typescript language server to check the code (for example through Vetur), add types to `types` array in your `tsconfig.json`:
 
-
+```js
+{
+  "compilerOptions": {
+    "types": [
+      "nuxt-i18n"
+    ]
+}
+```


### PR DESCRIPTION
Removing link to CMTY as nobody replies there (I just did a bit but I don't think I'll able to keep monitoring it).