### PR TITLE
fix(types): various fixes to type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "eslintIgnore": [
     "src/templates/*.*",
-    "src/plugins/*.*"
+    "src/plugins/*.*",
+    "**/*.d.ts"
   ],
   "files": [
     "src",

--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -90,7 +90,6 @@ export default async (context) => {
         return cookies[cookieKey]
       }
     }
-    return null
   }
 
   const setLocaleCookie = locale => {

--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -184,11 +184,6 @@ export default async (context) => {
   // Current route. Updated from middleware also.
   app.i18n.__route = route
 
-  // Extension of Vue
-  if (!app.$t) {
-    app.$t = app.i18n.t
-  }
-
   // Inject seo function
   Vue.prototype.$nuxtI18nSeo = nuxtI18nSeo
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,2 +1,4 @@
 // augment typings of Vue.js
-import "./vue";
+import './vue'
+
+export { NuxtVueI18n } from './nuxt-i18n'

--- a/types/nuxt-i18n.d.ts
+++ b/types/nuxt-i18n.d.ts
@@ -1,0 +1,79 @@
+import VueI18n, { IVueI18n } from 'vue-i18n'
+import { MetaInfo } from 'vue-meta'
+
+/**
+ * The nuxt-i18n types namespace
+ */
+declare namespace NuxtVueI18n {
+  type Locale = VueI18n.Locale
+
+  namespace Options {
+    // e.g.:
+    // [
+    //   { code: 'en', iso: 'en-US', file: 'en.js' },
+    //   { code: 'fr', iso: 'fr-FR', file: 'fr.js' },
+    //   { code: 'es', iso: 'es-ES', file: 'es.js' }
+    // ]
+    interface LocaleObject {
+      code: Locale
+      // can be undefined: https://goo.gl/cCGKUV
+      iso?: string
+      // can be undefined: https://goo.gl/ryc5pF
+      file?: string
+      // Allow custom properties, e.g. "name": https://goo.gl/wrcb2G
+      [key: string]: any
+    }
+
+    interface DetectBrowserLanguageInterface {
+      useCookie?: boolean
+      cookieKey?: string
+      alwaysRedirect?: boolean
+      fallbackLocale?: Locale | null
+    }
+
+    interface VuexInterface {
+      moduleName?: string
+      syncLocale?: boolean
+      syncMessages?: boolean
+      syncRouteParams?: boolean
+    }
+
+    // options that are also exposed on VueI18n instance: https://goo.gl/UwNfZo
+    interface NuxtI18nInterface {
+      beforeLanguageSwitch?: () => any
+      defaultLocale?: null | Locale
+      locales?: Array<Locale | LocaleObject>
+      differentDomains?: boolean
+      forwardedHost?: boolean
+      onLanguageSwitched?: () => any
+    }
+
+    // see options reference: https://github.com/nuxt-community/nuxt-i18n/blob/master/docs/options-reference.md
+    interface AllOptionsInterface extends NuxtI18nInterface {
+      baseUrl?: string
+      detectBrowserLanguage?: DetectBrowserLanguageInterface
+      encodePaths?: boolean
+      langDir?: string | null
+      lazy?: boolean
+      // see https://goo.gl/NbzX3f
+      pages?: {
+        [key: string]: boolean | {
+          [key: string]: boolean | string
+        }
+      }
+      parsePages?: boolean
+      rootRedirect?: string | null
+      routesNameSeparator?: string
+      seo?: boolean
+      strategy?: 'no_prefix' | 'prefix_except_default' | 'prefix' | 'prefix_and_default'
+      vueI18n?: VueI18n.I18nOptions
+      vuex?: VuexInterface
+    }
+  }
+}
+
+export interface NuxtI18nSeo {
+  htmlAttrs?: MetaInfo['htmlAttrs']
+  link?: MetaInfo['link']
+  meta?: MetaInfo['meta']
+}

--- a/types/nuxt-i18n.d.ts
+++ b/types/nuxt-i18n.d.ts
@@ -77,3 +77,10 @@ export interface NuxtI18nSeo {
   link?: MetaInfo['link']
   meta?: MetaInfo['meta']
 }
+
+export interface NuxtI18nComponentOptions {
+  paths?: {
+    [key: string]: string | false
+  }
+  locales?: Array<string>
+}

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -106,3 +106,12 @@ declare module "vue-i18n" {
     setLocale: (locale: string) => Promise<undefined>
   }
 }
+
+/**
+ * Extends types in Nuxt
+ */
+declare module '@nuxt/types/app' {
+  interface NuxtAppOptions extends NuxtVueI18n.Options.NuxtI18nInterface {
+    readonly i18n: VueI18n & IVueI18n
+  }
+}

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -50,7 +50,7 @@ declare namespace NuxtVueI18n {
       routesNameSeparator: string
       beforeLanguageSwitch: () => any
       onLanguageSwitched: () => any
-      getLocaleCookie: () => string | undefined | null
+      getLocaleCookie: () => string | undefined
       setLocaleCookie: (locale: string) => undefined
       setLocale: (locale: string) => Promise<undefined>
     }

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -1,7 +1,8 @@
+import Vue from 'vue'
 import { RawLocation } from 'vue-router'
 import VueI18n, { IVueI18n } from 'vue-i18n'
 import { MetaInfo } from 'vue-meta'
-import { NuxtVueI18n, NuxtI18nSeo } from './nuxt-i18n'
+import { NuxtI18nComponentOptions, NuxtVueI18n, NuxtI18nSeo } from './nuxt-i18n'
 
 /**
  * Extends types in vue-i18n
@@ -27,6 +28,12 @@ declare module 'vue/types/vue' {
     $nuxtI18nSeo(): NuxtI18nSeo
     // PHPStorm without this indicates that "$i18n" was not found.
     readonly $i18n: VueI18n & IVueI18n
+  }
+}
+
+declare module 'vue/types/options' {
+  interface ComponentOptions<V extends Vue> {
+    nuxtI18n?: NuxtI18nComponentOptions | false
   }
 }
 

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -1,109 +1,32 @@
-import Vue from "vue";
-import { RawLocation } from "vue-router";
-import VueI18n, { IVueI18n } from "vue-i18n";
+import { RawLocation } from 'vue-router'
+import VueI18n, { IVueI18n } from 'vue-i18n'
 import { MetaInfo } from 'vue-meta'
-
-/**
- * The nuxt-i18n types namespace
- */
-declare namespace NuxtVueI18n {
-  type Locale = VueI18n.Locale
-
-  namespace Options {
-    // e.g.:
-    // [
-    //   { code: 'en', iso: 'en-US', file: 'en.js' },
-    //   { code: 'fr', iso: 'fr-FR', file: 'fr.js' },
-    //   { code: 'es', iso: 'es-ES', file: 'es.js' }
-    // ]
-    interface LocaleObject {
-      code: Locale
-      // can be undefined: https://goo.gl/cCGKUV
-      iso?: string
-      // can be undefined: https://goo.gl/ryc5pF
-      file?: string
-      // Allow custom properties, e.g. "name": https://goo.gl/wrcb2G
-      [key: string]: any
-    }
-
-    interface DetectBrowserLanguageInterface {
-      useCookie?: boolean
-      cookieKey?: string
-      alwaysRedirect?: boolean
-      fallbackLocale?: Locale | null
-    }
-
-    interface VuexInterface {
-      moduleName?: string
-      syncLocale?: boolean
-      syncMessages?: boolean
-      syncRouteParams?: boolean
-    }
-
-    // options that are also exposed on VueI18n instance: https://goo.gl/UwNfZo
-    interface NuxtI18nInterface {
-      beforeLanguageSwitch?: () => any
-      defaultLocale?: null | Locale
-      locales?: Array<Locale | LocaleObject>
-      differentDomains?: boolean
-      forwardedHost?: boolean
-      onLanguageSwitched?: () => any
-    }
-
-    // see options reference: https://github.com/nuxt-community/nuxt-i18n/blob/master/docs/options-reference.md
-    interface AllOptionsInterface extends NuxtI18nInterface {
-      baseUrl?: string
-      detectBrowserLanguage?: DetectBrowserLanguageInterface
-      encodePaths?: boolean
-      langDir?: string | null
-      lazy?: boolean
-      // see https://goo.gl/NbzX3f
-      pages?: {
-        [key: string]: boolean | {
-          [key: string]: boolean | string
-        }
-      }
-      parsePages?: boolean
-      rootRedirect?: string | null
-      routesNameSeparator?: string
-      seo?: boolean
-      strategy?: "no_prefix" | "prefix_except_default" | "prefix" | "prefix_and_default"
-      vueI18n?: VueI18n.I18nOptions
-      vuex?: VuexInterface
-    }
-  }
-}
-
-export interface NuxtI18nSeo {
-  htmlAttrs?: MetaInfo['htmlAttrs']
-  link?: MetaInfo['link']
-  meta?: MetaInfo['meta']
-}
-
-/**
- * Extends types in vue
- */
-declare module "vue/types/vue" {
-  interface Vue {
-    localePath(route: RawLocation, locale?: string): string;
-    switchLocalePath(locale: string): string;
-    getRouteBaseName(route: RawLocation): string;
-    $nuxtI18nSeo(): NuxtI18nSeo;
-    // PHPStorm without this indicates that "$i18n" was not found.
-    readonly $i18n: VueI18n & IVueI18n;
-  }
-}
+import { NuxtVueI18n, NuxtI18nSeo } from './nuxt-i18n'
 
 /**
  * Extends types in vue-i18n
  */
-declare module "vue-i18n" {
+declare module 'vue-i18n' {
   // the VueI18n class expands here: https://goo.gl/Xtp9EG
   // it is necessary for the $i18n property in Vue interface: "readonly $i18n: VueI18n & IVueI18n"
   interface IVueI18n extends NuxtVueI18n.Options.NuxtI18nInterface {
     getLocaleCookie: () => string | undefined
     setLocaleCookie: (locale: string) => undefined
     setLocale: (locale: string) => Promise<undefined>
+  }
+}
+
+/**
+ * Extends types in vue
+ */
+declare module 'vue/types/vue' {
+  interface Vue {
+    localePath(route: RawLocation, locale?: string): string
+    switchLocalePath(locale: string): string
+    getRouteBaseName(route?: RawLocation): string
+    $nuxtI18nSeo(): NuxtI18nSeo
+    // PHPStorm without this indicates that "$i18n" was not found.
+    readonly $i18n: VueI18n & IVueI18n
   }
 }
 

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -51,9 +51,6 @@ declare namespace NuxtVueI18n {
       routesNameSeparator: string
       beforeLanguageSwitch: () => any
       onLanguageSwitched: () => any
-      getLocaleCookie: () => string | undefined
-      setLocaleCookie: (locale: string) => undefined
-      setLocale: (locale: string) => Promise<undefined>
     }
 
     // see options reference: https://github.com/nuxt-community/nuxt-i18n/blob/master/docs/options-reference.md
@@ -106,6 +103,8 @@ declare module "vue-i18n" {
   // the VueI18n class expands here: https://goo.gl/Xtp9EG
   // it is necessary for the $i18n property in Vue interface: "readonly $i18n: VueI18n & IVueI18n"
   interface IVueI18n extends NuxtVueI18n.Options.VueI18nInterface {
-
+    getLocaleCookie: () => string | undefined
+    setLocaleCookie: (locale: string) => undefined
+    setLocale: (locale: string) => Promise<undefined>
   }
 }

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -1,6 +1,7 @@
 import Vue from "vue";
 import { RawLocation } from "vue-router";
 import VueI18n, { IVueI18n } from "vue-i18n";
+import { MetaInfo } from 'vue-meta'
 
 /**
  * The nuxt-i18n types namespace
@@ -78,22 +79,10 @@ declare namespace NuxtVueI18n {
   }
 }
 
-interface NuxtI18nSeo {
-  htmlAttrs?: {
-    lang?: string
-  }
-  link?: {
-    hid: string,
-    rel: string,
-    href: string,
-    hreflang: string
-  }[]
-  meta?: {
-    hid: string,
-    name: string,
-    property: string,
-    content: string
-  }[]
+export interface NuxtI18nSeo {
+  htmlAttrs?: MetaInfo['htmlAttrs']
+  link?: MetaInfo['link']
+  meta?: MetaInfo['meta']
 }
 
 /**

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -27,51 +27,49 @@ declare namespace NuxtVueI18n {
     }
 
     interface DetectBrowserLanguageInterface {
-      useCookie: boolean
-      cookieKey: string
-      alwaysRedirect: boolean
-      fallbackLocale: Locale | null
+      useCookie?: boolean
+      cookieKey?: string
+      alwaysRedirect?: boolean
+      fallbackLocale?: Locale | null
     }
 
-    interface Vuex {
-      moduleName: string
-      mutations: {
-        setLocale: string
-        setMessages: string
-      }
-      preserveState: boolean
+    interface VuexInterface {
+      moduleName?: string
+      syncLocale?: boolean
+      syncMessages?: boolean
+      syncRouteParams?: boolean
     }
 
-    // special options for a "app.i18n" property: https://goo.gl/UwNfZo
-    interface VueI18nInterface {
-      locales: Array<Locale | LocaleObject>
-      defaultLocale: null | Locale
-      differentDomains: boolean
-      forwardedHost: boolean
-      routesNameSeparator: string
-      beforeLanguageSwitch: () => any
-      onLanguageSwitched: () => any
+    // options that are also exposed on VueI18n instance: https://goo.gl/UwNfZo
+    interface NuxtI18nInterface {
+      beforeLanguageSwitch?: () => any
+      defaultLocale?: null | Locale
+      locales?: Array<Locale | LocaleObject>
+      differentDomains?: boolean
+      forwardedHost?: boolean
+      onLanguageSwitched?: () => any
     }
 
     // see options reference: https://github.com/nuxt-community/nuxt-i18n/blob/master/docs/options-reference.md
-    interface AllOptionsInterface extends VueI18nInterface {
-      vueI18n: VueI18n.I18nOptions
-      strategy: "prefix_except_default" | "prefix" | "prefix_and_default"
-      lazy: boolean
-      langDir: string | null
-      rootRedirect: string | null
-      detectBrowserLanguage: Options.DetectBrowserLanguageInterface
-      seo: boolean
-      baseUrl: string
-      vuex: Options.Vuex
-      parsePages: boolean
+    interface AllOptionsInterface extends NuxtI18nInterface {
+      baseUrl?: string
+      detectBrowserLanguage?: DetectBrowserLanguageInterface
+      encodePaths?: boolean
+      langDir?: string | null
+      lazy?: boolean
       // see https://goo.gl/NbzX3f
-      pages: {
+      pages?: {
         [key: string]: boolean | {
           [key: string]: boolean | string
         }
       }
-      encodePaths: boolean
+      parsePages?: boolean
+      rootRedirect?: string | null
+      routesNameSeparator?: string
+      seo?: boolean
+      strategy?: "no_prefix" | "prefix_except_default" | "prefix" | "prefix_and_default"
+      vueI18n?: VueI18n.I18nOptions
+      vuex?: VuexInterface
     }
   }
 }
@@ -102,7 +100,7 @@ declare module "vue/types/vue" {
 declare module "vue-i18n" {
   // the VueI18n class expands here: https://goo.gl/Xtp9EG
   // it is necessary for the $i18n property in Vue interface: "readonly $i18n: VueI18n & IVueI18n"
-  interface IVueI18n extends NuxtVueI18n.Options.VueI18nInterface {
+  interface IVueI18n extends NuxtVueI18n.Options.NuxtI18nInterface {
     getLocaleCookie: () => string | undefined
     setLocaleCookie: (locale: string) => undefined
     setLocale: (locale: string) => Promise<undefined>


### PR DESCRIPTION
Changes:
 - exported `NuxtVueI18n` namespace to allow to annotate configuration
   object in `nuxt.config.ts`.
 - fixed various types in Options, made all optional to make them
   actually usable, added missing ones.
 - moved getLocaleCookie, setLocaleCookie and SetLocale to proper
   interface.
 - removed `return null` from `getLocaleCookie` to simplify types.
 - Updated NuxtI18nSeo interface to use VueMeta types.
 - Also removed `app.$t` API as it never worked - it needs to be called
   on the VueI18n instance instead.