### PR TITLE
docs: add documentation page with API reference

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -15,7 +15,12 @@ module.exports = {
           '/': sidebarLinks('en')
         }
       },
-    }
+    },
+    nav: [
+      { text: 'Guide', link: '/' },
+      { text: 'API Reference', link: '/api/' },
+      { text: 'Release Notes', link: 'https://github.com/nuxt-community/nuxt-i18n/blob/master/CHANGELOG.md' }
+    ]
   }
 }
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,158 @@
+---
+sidebar: auto
+---
+
+# API Reference
+
+## Extension of Vue
+
+::: tip
+**NOTE**
+
+All [Vue I18n properties and methods](http://kazupon.github.io/vue-i18n/api/#vue-injected-methods) (like `$t`, `$i18n`, `v-t` directive and others) are also available even though they are not listed here. Below are only ones added by `nuxt-i18n`.
+:::
+
+### Methods
+
+#### localePath
+
+  - **Arguments**:
+    - route (type: `string` | [`Location`](https://github.com/vuejs/vue-router/blob/f40139c27a9736efcbda69ec136cb00d8e00fa97/types/router.d.ts#L125))
+    - locale (type: `string`, default: current locale)
+  - **Returns**: `string`
+
+  Returns localized path for passed in `route`. If `locale` is not specified, uses current locale.
+
+  See also [Basic usage - nuxt-link](../basic-usage.html#nuxt-link).
+
+::: warning
+In `no_prefix` strategy, passing `locale` other than the current one is not supported.
+:::
+
+#### switchLocalePath
+
+  - **Arguments**:
+    - locale: (type: `string`)
+  - **Returns**: `string`
+
+  Returns path of the current route for specified `locale`.
+
+  See also [Basic usage - nuxt-link](../basic-usage.html#nuxt-link).
+
+  See type definition for [Location](https://github.com/vuejs/vue-router/blob/f40139c27a9736efcbda69ec136cb00d8e00fa97/types/router.d.ts#L125).
+
+::: warning
+In `no_prefix` strategy, passing `locale` other than the current one is not supported.
+:::
+
+#### getRouteBaseName
+
+  - **Arguments**:
+    - route (type: `string` | [`Location`](https://github.com/vuejs/vue-router/blob/f40139c27a9736efcbda69ec136cb00d8e00fa97/types/router.d.ts#L125), default: current route)
+  - **Returns**: `string`
+
+  Returns base name of current (if argument not provided) or passed in `route`. Base name is name of the route without locale suffix and other metadata added by `nuxt-i18n`.
+
+#### $nuxtI18nSeo
+
+  - **Arguments**:
+    - no arguments
+  - **Returns**: `NuxtI18nSeo`
+
+  SEO object provided mostly for use with [SEO - Improving Performance](../seo.html#improving-performance).
+
+## Extension of VueI18n
+
+::: tip
+Instance of [VueI18n class](http://kazupon.github.io/vue-i18n/api/#vuei18n-class) (see its [properties and methods](http://kazupon.github.io/vue-i18n/api/#properties)) is exposed as `$i18n` on Vue instance and as `i18n` on Nuxt `context.app`.
+:::
+
+### Methods
+
+#### getLocaleCookie
+
+  - **Arguments**:
+    - no arguments
+  - **Returns**: `string | undefined`
+
+  Returns locale code from stored locale cookie.
+
+#### setLocaleCookie
+
+  - **Arguments**:
+    - locale (type: `string`)
+  - **Returns**: `undefined`
+
+  Updates stored locale cookie with specified locale code. Consider using `setLocale` instead if you want to switch locale.
+
+#### setLocale
+
+  > :new: 6.1.0+
+
+  - **Arguments**:
+    - locale (type: `string`)
+  - **Returns**: `Promise<undefined>`
+
+  Switches locale of the app to specified locale code. If `useCookie` option is enabled, locale cookie will be updated with new value. If prefixes are enabled (`strategy` other than `no_prefix`), will navigate to new locale's route.
+
+### Properties
+
+#### defaultLocale
+
+  - **Type**: `string`
+
+  Default locale as specified in options.
+
+#### locales
+
+  - **Type**: `Array<string | LocaleObject>`
+
+  List of locales as defined in options.
+
+#### differentDomains
+
+  - **Type**: `boolean`
+
+  Whether `differentDomains` option is enabled.
+
+#### forwardedHost
+
+  - **Type**: `boolean`
+
+  Whether `forwardedHost` option is enabled.
+
+#### beforeLanguageSwitch
+
+  - **Type**: `Function`
+
+  See [callbacks](../callbacks.html)
+
+#### onLanguageSwitched
+
+  - **Type**: `Function`
+
+  See [callbacks](../callbacks.html)
+
+## Extension of Nuxt Context
+
+### context.app.i18n
+
+  - **Type**: `VueI18n`
+
+See also [Nuxt context](https://nuxtjs.org/api/context#the-context).
+
+Can be accessed from `asyncData` and wherever `context` is available.
+
+Example use:
+
+```js
+export default Vue.extend({
+  asyncData({ app }) {
+    const locale = app.i18n.locale
+
+    return {
+      locale
+    }
+  }
+})
+````

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -44,9 +44,13 @@ There are four supported strategies for generating the app's routes:
 
 ### no_prefix
 
+> :new: 6.1.0
+
 With this strategy, your routes won't have a locale prefix added. The locale will be detected & changed without changing the URL. This implies that you have to rely on browser & cookie detection, and implement locale switches by calling the i18n API.
 
-> NOTE: This strategy doesn't support [Custom paths](#custom-paths) and [Ignore routes](#ignore-routes) features.
+::: warning
+This strategy doesn't support [Custom paths](#custom-paths) and [Ignore routes](#ignore-routes) features.
+:::
 
 ### prefix_except_default
 


### PR DESCRIPTION
Note that current `vuepress` version fails to run when there is also `nuxt` in dependencies so `yarn remove nuxt` for testing.

Resolves #282