### PR TITLE
Add support for using 'path' parameter in localePath(...)

### DIFF
--- a/src/plugins/routing.js
+++ b/src/plugins/routing.js
@@ -27,6 +27,14 @@ function localePathFactory (i18nPath, routerPath) {
       route = { name: route }
     }
 
+    // if route has a path defined but no route name, generate path without route
+    if (route.path && !route.name) {
+      // prepend locale if current is not default and not using different domains
+      const appendPath = locale !== defaultLocale && !this[i18nPath].differentDomains
+      const fullPath = (appendPath ? `/${locale}${route.path}` : route.path)
+      return fullPath
+    }
+
     // Build localized route options
     let name = route.name + (STRATEGY === STRATEGIES.NO_PREFIX ? '' : routesNameSeparator + locale)
 

--- a/src/plugins/routing.js
+++ b/src/plugins/routing.js
@@ -27,31 +27,42 @@ function localePathFactory (i18nPath, routerPath) {
       route = { name: route }
     }
 
-    // if route has a path defined but no route name, generate path without route
+    let localizedRoute
+    const router = this[routerPath]
+
     if (route.path && !route.name) {
-      // prepend locale if current is not default and not using different domains
-      const appendPath = !(locale === defaultLocale && strategy === STRATEGIES.PREFIX_EXCEPT_DEFAULT) && !this[i18nPath].differentDomains
-      const fullPath = (appendPath ? `/${locale}${route.path}` : route.path)
-      return fullPath
-    }
+      // if route has a path defined but no name, resolve full route using the path
+      const isPrefixed = (
+        // don't prefix default locale
+        !(locale === defaultLocale && STRATEGY === STRATEGIES.PREFIX_EXCEPT_DEFAULT) &&
+        // no prefix for any language
+        !(STRATEGY === STRATEGIES.NO_REFIX) &&
+        // no prefix for different domains
+        !this[i18nPath].differentDomains
+      )
 
-    // Build localized route options
-    let name = route.name + (STRATEGY === STRATEGIES.NO_PREFIX ? '' : routesNameSeparator + locale)
+      const path = (isPrefixed ? `/${locale}${route.path}` : route.path)
 
-    // Match route without prefix for default locale
-    if (locale === defaultLocale && STRATEGY === STRATEGIES.PREFIX_AND_DEFAULT) {
-      name += routesNameSeparator + defaultLocaleRouteNameSuffix
-    }
+      localizedRoute = Object.assign({}, route, { path })
+    } else {
+      // otherwise resolve route via the route name
+      // Build localized route options
+      let name = route.name + (STRATEGY === STRATEGIES.NO_PREFIX ? '' : routesNameSeparator + locale)
 
-    const localizedRoute = Object.assign({}, route, { name })
+      // Match route without prefix for default locale
+      if (locale === defaultLocale && STRATEGY === STRATEGIES.PREFIX_AND_DEFAULT) {
+        name += routesNameSeparator + defaultLocaleRouteNameSuffix
+      }
 
-    const { params } = localizedRoute
-    if (params && params['0'] === undefined && params.pathMatch) {
-      params['0'] = params.pathMatch
+      localizedRoute = Object.assign({}, route, { name })
+
+      const { params } = localizedRoute
+      if (params && params['0'] === undefined && params.pathMatch) {
+        params['0'] = params.pathMatch
+      }
     }
 
     // Resolve localized route
-    const router = this[routerPath]
     const { route: { fullPath } } = router.resolve(localizedRoute)
     return fullPath
   }

--- a/src/plugins/routing.js
+++ b/src/plugins/routing.js
@@ -30,7 +30,7 @@ function localePathFactory (i18nPath, routerPath) {
     // if route has a path defined but no route name, generate path without route
     if (route.path && !route.name) {
       // prepend locale if current is not default and not using different domains
-      const appendPath = locale !== defaultLocale && !this[i18nPath].differentDomains
+      const appendPath = !(locale === defaultLocale && strategy === STRATEGIES.PREFIX_EXCEPT_DEFAULT) && !this[i18nPath].differentDomains
       const fullPath = (appendPath ? `/${locale}${route.path}` : route.path)
       return fullPath
     }


### PR DESCRIPTION
Hey! Trying to determine whether or not support for this is worth pursuing, or if this is already an issue that can't be supported for whatever reason. This also builds on #215.

Here's the issue:

If you need to dynamically generate a localized route, there is no way to do so because you need to pass the route's name to `localePath` for it to generate the correct path. 

In my case, I need to be able to generate a dynamic path based on a response from a remote database, which only knows of the route's path, not the name. 

My proposal is to add support for using the `path` key in `localePath({ ... })`. 

Example:

Given languages: `en` *(default)* and `ru`

```js
localePath({ path: '/dashboard' })
``` 

Will generate `/dashboard` and `/ru/dashboard` respectively.

This is comparable to using `localePath({ name: 'dashboard' })` or `localePath('dashboard')`, but in this instance we don't know the name of the route, so it can't be used.

In order to check whether or not the plugin should use the `path` parameter, I ensure it's presence and then double check that the `name` parameter is not also supplied, in which case we'll skip this because we have a more accurate way of resolving the route. This prevents conflict with the `switchLocalePath()` functionality, which passes both `name` and `route` to `localePath()` when generating the path to switch languages. 

Then I determine whether or not the locale needs to be prepended to the path based on a) not using the default locale and we're not using a strategy that prefixes the default locale, and b) not using the differentDomains functionality.

I'll of course add tests and so-on, again, assuming that this can be pursued.