### PR TITLE
refactor: avoid using templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "docs:build": "vuepress build docs"
   },
   "eslintIgnore": [
-    "src/templates/*.*",
-    "src/plugins/*.*",
+    "src/templates/options.js",
     "**/*.d.ts"
   ],
   "files": [

--- a/src/helpers/components.js
+++ b/src/helpers/components.js
@@ -40,7 +40,7 @@ exports.extractComponentOptions = (path) => {
       }
     })
   } catch (error) {
-    // eslint-disable-next-line
+    // eslint-disable-next-line no-console
     console.warn('[' + MODULE_NAME + `] Error parsing "${COMPONENT_OPTIONS_KEY}" component option in file "${path}".`)
   }
 

--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -62,7 +62,7 @@ exports.makeRoutes = (baseRoutes, {
 
       // Skip if locale not in module's configuration
       if (locales.indexOf(locale) === -1) {
-        // eslint-disable-next-line
+        // eslint-disable-next-line no-console
         console.warn(`[${MODULE_NAME}] Can't generate localized route for route '${name}' with locale '${locale}' because locale is not in the module's configuration`)
         continue
       }

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -1,6 +1,4 @@
-/* global app, req, vuex, store */
-
-const { LOCALE_CODE_KEY, LOCALE_DOMAIN_KEY } = require('./constants')
+const { LOCALE_CODE_KEY } = require('./constants')
 
 /**
  * Get an array of locale codes from a list of locales
@@ -65,88 +63,4 @@ exports.getPageOptions = (route, pages, locales, pagesDir, defaultLocale) => {
     })
 
   return options
-}
-
-/**
- * Extract locale code from given route:
- * - If route has a name, try to extract locale from it
- * - Otherwise, fall back to using the routes'path
- * @param  {Object} route               Route
- * @param  {String} routesNameSeparator Separator used to add locale suffixes in routes names
- * @param  {String} defaultLocaleRouteNameSuffix Suffix added to default locale routes names
- * @param  {Array}  locales             Locales list from nuxt config
- * @return {String}                     Locale code found if any
- */
-exports.getLocaleFromRoute = (route = {}, routesNameSeparator = '', defaultLocaleRouteNameSuffix = '', locales = []) => {
-  const codes = getLocaleCodes(locales)
-  const localesPattern = `(${codes.join('|')})`
-  const defaultSuffixPattern = `(?:${routesNameSeparator}${defaultLocaleRouteNameSuffix})?`
-  // Extract from route name
-  if (route.name) {
-    const regexp = new RegExp(`${routesNameSeparator}${localesPattern}${defaultSuffixPattern}$`, 'i')
-    const matches = route.name.match(regexp)
-    if (matches && matches.length > 1) {
-      return matches[1]
-    }
-  } else if (route.path) {
-    // Extract from path
-    const regexp = new RegExp(`^/${localesPattern}/`, 'i')
-    const matches = route.path.match(regexp)
-    if (matches && matches.length > 1) {
-      return matches[1]
-    }
-  }
-  return null
-}
-
-/**
- * Get x-forwarded-host
- * @return {String} x-forwarded-host
- */
-const getForwarded = () => (
-  process.browser ? window.location.href.split('/')[2] : (req.headers['x-forwarded-host'] ? req.headers['x-forwarded-host'] : req.headers.host)
-)
-
-exports.getForwarded = getForwarded
-
-/**
- * Get hostname
- * @return {String} Hostname
- */
-const getHostname = () => (
-  process.browser ? window.location.href.split('/')[2] : req.headers.host // eslint-disable-line
-)
-
-exports.getHostname = getHostname
-
-/**
- * Get locale code that corresponds to current hostname
- * @return {String} Locade code found if any
- */
-exports.getLocaleDomain = () => {
-  const hostname = app.i18n.forwardedHost ? getForwarded() : getHostname()
-  if (hostname) {
-    const localeDomain = app.i18n.locales.find(l => l[LOCALE_DOMAIN_KEY] === hostname) // eslint-disable-line
-    if (localeDomain) {
-      return localeDomain[LOCALE_CODE_KEY]
-    }
-  }
-  return null
-}
-
-/**
- * Dispatch store module actions to keep it in sync with app's locale data
- * @param  {String} locale   Current locale
- * @param  {Object} messages Current messages
- * @return {Promise(void)}
- */
-exports.syncVuex = async (locale = null, messages = null) => {
-  if (vuex && store) {
-    if (locale !== null && vuex.syncLocale) {
-      await store.dispatch(vuex.moduleName + '/setLocale', locale)
-    }
-    if (messages !== null && vuex.syncMessages) {
-      await store.dispatch(vuex.moduleName + '/setMessages', messages)
-    }
-  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -18,12 +18,7 @@ const {
 } = require('./helpers/constants')
 
 const {
-  getLocaleCodes,
-  getLocaleFromRoute,
-  getForwarded,
-  getHostname,
-  getLocaleDomain,
-  syncVuex
+  getLocaleCodes
 } = require('./helpers/utils')
 
 module.exports = function (userOptions) {
@@ -54,12 +49,7 @@ module.exports = function (userOptions) {
     LOCALE_FILE_KEY,
     STRATEGIES,
     COMPONENT_OPTIONS_KEY,
-    getLocaleCodes,
-    getLocaleFromRoute,
-    getForwarded,
-    getHostname,
-    getLocaleDomain,
-    syncVuex
+    localeCodes: getLocaleCodes(options.locales)
   }
 
   // Generate localized routes

--- a/src/plugins/seo.js
+++ b/src/plugins/seo.js
@@ -2,7 +2,7 @@ import Vue from 'vue'
 import { nuxtI18nSeo } from './seo-head'
 
 const plugin = {
-  install(Vue) {
+  install (Vue) {
     Vue.mixin({
       head: nuxtI18nSeo
     })

--- a/src/templates/middleware.js
+++ b/src/templates/middleware.js
@@ -1,18 +1,15 @@
 import middleware from '../middleware'
+import { detectBrowserLanguage, rootRedirect } from './options'
+import { getLocaleFromRoute } from './utils'
 
-middleware['i18n'] = async (context) => {
-  const { app, req, route, redirect, isHMR } = context
+middleware.i18n = async (context) => {
+  const { app, route, redirect, isHMR } = context
 
   if (isHMR) {
     return
   }
 
-  // Helpers
-  const LOCALE_CODE_KEY = '<%= options.LOCALE_CODE_KEY %>'
-  const getLocaleCodes = <%= options.getLocaleCodes %>
-
   // Handle root path redirect
-  const rootRedirect = '<%= options.rootRedirect %>'
   if (route.path === '/' && rootRedirect) {
     redirect('/' + rootRedirect, route.query)
     return
@@ -21,19 +18,12 @@ middleware['i18n'] = async (context) => {
   // Update for setLocale to have up to date route
   app.i18n.__route = route
 
-  const detectBrowserLanguage = <%= JSON.stringify(options.detectBrowserLanguage) %>
-
   if (detectBrowserLanguage && await app.i18n.__detectBrowserLanguage(route)) {
     return
   }
 
   const locale = app.i18n.locale || app.i18n.defaultLocale || null
-  const getLocaleFromRoute = <%= options.getLocaleFromRoute %>
-  const routesNameSeparator = '<%= options.routesNameSeparator %>'
-  const defaultLocaleRouteNameSuffix = '<%= options.defaultLocaleRouteNameSuffix %>'
-  const locales = getLocaleCodes(<%= JSON.stringify(options.locales) %>)
+  const routeLocale = getLocaleFromRoute(route)
 
-  const routeLocale = getLocaleFromRoute(route, routesNameSeparator, defaultLocaleRouteNameSuffix, locales)
-
-  await app.i18n.setLocale(routeLocale ? routeLocale : locale)
+  await app.i18n.setLocale(routeLocale || locale)
 }

--- a/src/templates/options.js
+++ b/src/templates/options.js
@@ -1,0 +1,15 @@
+<%
+function stringifyValue(value) {
+  if (typeof value === 'string') {
+    return `'${value}'`
+  } else if (value === undefined || value === null || typeof value === 'boolean' || typeof value === 'function') {
+    return String(value);
+  } else {
+    return JSON.stringify(value)
+  }
+}
+
+for (const [key, value] of Object.entries(options)) {
+%>
+export const <%= key %> = <%= stringifyValue(value) %>
+<% } %>

--- a/src/templates/seo-head.js
+++ b/src/templates/seo-head.js
@@ -1,11 +1,13 @@
 import VueMeta from 'vue-meta'
-
-const COMPONENT_OPTIONS_KEY = '<%= options.COMPONENT_OPTIONS_KEY %>'
-const LOCALE_CODE_KEY = '<%= options.LOCALE_CODE_KEY %>'
-const LOCALE_ISO_KEY = '<%= options.LOCALE_ISO_KEY %>'
-const BASE_URL = '<%= options.baseUrl %>'
-const STRATEGIES = <%= JSON.stringify(options.STRATEGIES) %>
-const STRATEGY = '<%= options.strategy %>'
+import {
+  baseUrl,
+  COMPONENT_OPTIONS_KEY,
+  LOCALE_CODE_KEY,
+  LOCALE_ISO_KEY,
+  MODULE_NAME,
+  STRATEGIES,
+  strategy
+} from './options'
 
 export const nuxtI18nSeo = function () {
   if (
@@ -16,7 +18,7 @@ export const nuxtI18nSeo = function () {
     this.$options[COMPONENT_OPTIONS_KEY] === false ||
     (this.$options[COMPONENT_OPTIONS_KEY] && this.$options[COMPONENT_OPTIONS_KEY].seo === false)
   ) {
-    return {};
+    return {}
   }
   // Prepare html lang attribute
   const currentLocaleData = this.$i18n.locales.find(l => l[LOCALE_CODE_KEY] === this.$i18n.locale)
@@ -27,18 +29,19 @@ export const nuxtI18nSeo = function () {
 
   const link = []
   // hreflang tags
-  if (STRATEGY !== STRATEGIES.NO_PREFIX) {
+  if (strategy !== STRATEGIES.NO_PREFIX) {
     link.push(...this.$i18n.locales
       .map(locale => {
         if (locale[LOCALE_ISO_KEY]) {
           return {
             hid: 'alternate-hreflang-' + locale[LOCALE_ISO_KEY],
             rel: 'alternate',
-            href: BASE_URL + this.switchLocalePath(locale.code),
+            href: baseUrl + this.switchLocalePath(locale.code),
             hreflang: locale[LOCALE_ISO_KEY]
           }
         } else {
-          console.warn('[<%= options.MODULE_NAME %>] Locale ISO code is required to generate alternate link')
+          // eslint-disable-next-line no-console
+          console.warn(`[${MODULE_NAME}] Locale ISO code is required to generate alternate link`)
           return null
         }
       })
@@ -46,14 +49,14 @@ export const nuxtI18nSeo = function () {
   }
 
   // canonical links
-  if (STRATEGY === STRATEGIES.PREFIX_AND_DEFAULT) {
+  if (strategy === STRATEGIES.PREFIX_AND_DEFAULT) {
     const canonicalPath = this.switchLocalePath(currentLocaleData[LOCALE_CODE_KEY])
     if (canonicalPath && canonicalPath !== this.$route.path) {
       // Current page is not the canonical one -- add a canonical link
       link.push({
         hid: 'canonical-lang-' + currentLocaleData[LOCALE_CODE_KEY],
         rel: 'canonical',
-        href: BASE_URL + canonicalPath
+        href: baseUrl + canonicalPath
       })
     }
   }
@@ -78,7 +81,7 @@ export const nuxtI18nSeo = function () {
         property: 'og:locale:alternate',
         content: locale[LOCALE_ISO_KEY].replace(/-/g, '_')
       }))
-  );
+  )
 
   return {
     htmlAttrs,

--- a/src/templates/utils.js
+++ b/src/templates/utils.js
@@ -1,11 +1,13 @@
-const LOCALE_CODE_KEY = '<%= options.LOCALE_CODE_KEY %>'
-const LOCALE_DOMAIN_KEY = '<%= options.LOCALE_DOMAIN_KEY %>'
-const LOCALE_FILE_KEY = '<%= options.LOCALE_FILE_KEY %>'
-const getLocaleCodes = <%= options.getLocaleCodes %>
-const locales = <%= JSON.stringify(options.locales) %>
-const localeCodes = getLocaleCodes(locales)
-
-const isObject = value => value && !Array.isArray(value) && typeof value === 'object'
+import {
+  defaultLocaleRouteNameSuffix,
+  localeCodes,
+  LOCALE_CODE_KEY,
+  LOCALE_DOMAIN_KEY,
+  LOCALE_FILE_KEY,
+  MODULE_NAME,
+  routesNameSeparator,
+  vuex
+} from './options'
 
 /**
  * Asynchronously load messages from translation files
@@ -13,7 +15,7 @@ const isObject = value => value && !Array.isArray(value) && typeof value === 'ob
  * @param  {String}   locale  Language code to load
  */
 export async function loadLanguageAsync (context, locale) {
-  const { app } = context;
+  const { app } = context
 
   if (!app.i18n.loadedLanguages) {
     app.i18n.loadedLanguages = []
@@ -24,7 +26,8 @@ export async function loadLanguageAsync (context, locale) {
     if (langOptions) {
       const file = langOptions[LOCALE_FILE_KEY]
       if (file) {
-        <% if (options.langDir) { %>
+        // Hiding template directives from eslint so that parsing doesn't break.
+        /* <% if (options.langDir) { %> */
         try {
           const module = await import(/* webpackChunkName: "lang-[request]" */ '~/<%= options.langDir %>' + file)
           const messages = module.default ? module.default : module
@@ -32,15 +35,19 @@ export async function loadLanguageAsync (context, locale) {
           app.i18n.setLocaleMessage(locale, result)
           app.i18n.loadedLanguages.push(locale)
         } catch (error) {
+          // eslint-disable-next-line no-console
           console.error(error)
         }
-        <% } %>
+        /* <% } %> */
       } else {
-        console.warn('[<%= options.MODULE_NAME %>] Could not find lang file for locale ' + locale)
+        // eslint-disable-next-line no-console
+        console.warn(`[${MODULE_NAME}] Could not find lang file for locale ${locale}`)
       }
     }
   }
 }
+
+const isObject = value => value && !Array.isArray(value) && typeof value === 'object'
 
 /**
  * Validate setRouteParams action's payload
@@ -48,14 +55,98 @@ export async function loadLanguageAsync (context, locale) {
  */
 export const validateRouteParams = routeParams => {
   if (!isObject(routeParams)) {
-    console.warn(`[<%= options.MODULE_NAME %>] Route params should be an object`)
+    // eslint-disable-next-line no-console
+    console.warn(`[${MODULE_NAME}] Route params should be an object`)
     return
   }
   Object.entries(routeParams).forEach(([key, value]) => {
     if (!localeCodes.includes(key)) {
-      console.warn(`[<%= options.MODULE_NAME %>] Trying to set route params for key ${key} which is not a valid locale`)
+    // eslint-disable-next-line no-console
+      console.warn(`[${MODULE_NAME}] Trying to set route params for key ${key} which is not a valid locale`)
     } else if (!isObject(value)) {
-      console.warn(`[<%= options.MODULE_NAME %>] Trying to set route params for locale ${key} with a non-object value`)
+    // eslint-disable-next-line no-console
+      console.warn(`[${MODULE_NAME}] Trying to set route params for locale ${key} with a non-object value`)
     }
   })
+}
+
+/**
+ * Get x-forwarded-host
+ * @param  {object} req
+ * @return {String} x-forwarded-host
+ */
+const getForwarded = req => (
+  process.client ? window.location.href.split('/')[2] : (req.headers['x-forwarded-host'] ? req.headers['x-forwarded-host'] : req.headers.host)
+)
+
+/**
+ * Get hostname
+ * @param  {object} req
+ * @return {String} Hostname
+ */
+const getHostname = req => (
+  process.client ? window.location.href.split('/')[2] : req.headers.host
+)
+
+/**
+ * Get locale code that corresponds to current hostname
+ * @param  {VueI18n} nuxtI18n Instance of VueI18n
+ * @param  {object} req Request object
+ * @return {String} Locade code found if any
+ */
+export const getLocaleDomain = (nuxtI18n, req) => {
+  const hostname = nuxtI18n.forwardedHost ? getForwarded(req) : getHostname(req)
+  if (hostname) {
+    const localeDomain = nuxtI18n.locales.find(l => l[LOCALE_DOMAIN_KEY] === hostname)
+    if (localeDomain) {
+      return localeDomain[LOCALE_CODE_KEY]
+    }
+  }
+  return null
+}
+
+/**
+ * Extract locale code from given route:
+ * - If route has a name, try to extract locale from it
+ * - Otherwise, fall back to using the routes'path
+ * @param  {Object} route               Route
+ * @return {String}                     Locale code found if any
+ */
+export const getLocaleFromRoute = (route = {}) => {
+  const localesPattern = `(${localeCodes.join('|')})`
+  const defaultSuffixPattern = `(?:${routesNameSeparator}${defaultLocaleRouteNameSuffix})?`
+  // Extract from route name
+  if (route.name) {
+    const regexp = new RegExp(`${routesNameSeparator}${localesPattern}${defaultSuffixPattern}$`, 'i')
+    const matches = route.name.match(regexp)
+    if (matches && matches.length > 1) {
+      return matches[1]
+    }
+  } else if (route.path) {
+    // Extract from path
+    const regexp = new RegExp(`^/${localesPattern}/`, 'i')
+    const matches = route.path.match(regexp)
+    if (matches && matches.length > 1) {
+      return matches[1]
+    }
+  }
+  return null
+}
+
+/**
+ * Dispatch store module actions to keep it in sync with app's locale data
+ * @param  {Store} store     Vuex store
+ * @param  {String} locale   Current locale
+ * @param  {Object} messages Current messages
+ * @return {Promise(void)}
+ */
+export const syncVuex = async (store, locale = null, messages = null) => {
+  if (vuex && store) {
+    if (locale !== null && vuex.syncLocale) {
+      await store.dispatch(vuex.moduleName + '/setLocale', locale)
+    }
+    if (messages !== null && vuex.syncMessages) {
+      await store.dispatch(vuex.moduleName + '/setMessages', messages)
+    }
+  }
 }


### PR DESCRIPTION
Since using lodash templates makes it impossible to properly lint files,
create options.js file that has all options stringified and exported so
that all other files can just import those without using templates.

That makes it possible to lint files and also see exactly which
variables are used and which are missing which was really hard when
whole functions were inlined when processing templates.

Instead of passing various functions through templates and stringifying
them, keep them in templates/utils.js and import directly. This also
has benefit of avoiding code duplication in processed files.

Compute localeCodes and some other variables up-front as when those are
based on user settings, they are guaranteed not to change so we don't
have to processes them on each request/route change.

`loadLanguageAsync` is one tricky function that needs to use templates
so that we don't include `import` statement when `langDir` is not defined.
To not break linting, added some hacky block comments to hide template
directives from linter.