### PR TITLE
Support routes with no component

### DIFF
--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -24,7 +24,7 @@ exports.makeRoutes = (baseRoutes, {
     const routes = []
     let pageOptions
 
-    // Skip route if it is only a redirect.
+    // Skip route if it is only a redirect without a component.
     if (route.redirect != null && !route.component) {
       return route
     }

--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -24,11 +24,14 @@ exports.makeRoutes = (baseRoutes, {
     const routes = []
     let pageOptions
 
+    // Skip route if it is a redirect.
+    if (route.redirect !== null) {
+      return route
+    }
+
     // Extract i18n options from page
     if (parsePages) {
-      if (route.component) {
-        pageOptions = extractComponentOptions(route.component)
-      }
+      pageOptions = extractComponentOptions(route.component)
     } else {
       pageOptions = getPageOptions(route, pages, locales, pagesDir, defaultLocale)
     }

--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -25,7 +25,7 @@ exports.makeRoutes = (baseRoutes, {
     let pageOptions
 
     // Extract i18n options from page
-    if (parsePages) {
+    if (parsePages && route.component) {
       pageOptions = extractComponentOptions(route.component)
     } else {
       pageOptions = getPageOptions(route, pages, locales, pagesDir, defaultLocale)

--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -25,7 +25,7 @@ exports.makeRoutes = (baseRoutes, {
     let pageOptions
 
     // Skip route if it is a redirect.
-    if (route.redirect !== null) {
+    if (route.redirect != null) {
       return route
     }
 

--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -25,8 +25,7 @@ exports.makeRoutes = (baseRoutes, {
     let pageOptions
 
     // Skip route if it is only a redirect without a component.
-    const hasRedirect = ({ redirect }) => redirect !== null || redirect !== undefined
-    if (hasRedirect(route) && !route.component) {
+    if (route.redirect && !route.component) {
       return route
     }
 

--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -24,8 +24,8 @@ exports.makeRoutes = (baseRoutes, {
     const routes = []
     let pageOptions
 
-    // Skip route if it is a redirect.
-    if (route.redirect != null) {
+    // Skip route if it is only a redirect.
+    if (route.redirect != null && !route.component) {
       return route
     }
 

--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -25,7 +25,8 @@ exports.makeRoutes = (baseRoutes, {
     let pageOptions
 
     // Skip route if it is only a redirect without a component.
-    if (route.redirect != null && !route.component) {
+    const hasRedirect = ({ redirect }) => redirect !== null || redirect !== undefined
+    if (hasRedirect(route) && !route.component) {
       return route
     }
 

--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -25,8 +25,10 @@ exports.makeRoutes = (baseRoutes, {
     let pageOptions
 
     // Extract i18n options from page
-    if (parsePages && route.component) {
-      pageOptions = extractComponentOptions(route.component)
+    if (parsePages) {
+      if (route.component) {
+        pageOptions = extractComponentOptions(route.component)
+      }
     } else {
       pageOptions = getPageOptions(route, pages, locales, pagesDir, defaultLocale)
     }

--- a/test/fixture/base.config.js
+++ b/test/fixture/base.config.js
@@ -41,5 +41,10 @@ module.exports = {
       },
       fallbackLocale: 'en'
     }
+  },
+  router: {
+    extendRoutes(routes) {
+      routes.push({ path: '/home', redirect: '/' })
+    }
   }
 }

--- a/test/fixture/base.config.js
+++ b/test/fixture/base.config.js
@@ -41,10 +41,5 @@ module.exports = {
       },
       fallbackLocale: 'en'
     }
-  },
-  router: {
-    extendRoutes (routes) {
-      routes.push({ path: '/home', redirect: '/' })
-    }
   }
 }

--- a/test/fixture/base.config.js
+++ b/test/fixture/base.config.js
@@ -43,7 +43,7 @@ module.exports = {
     }
   },
   router: {
-    extendRoutes(routes) {
+    extendRoutes (routes) {
       routes.push({ path: '/home', redirect: '/' })
     }
   }

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -136,7 +136,6 @@ describe('with redirect route', () => {
       router: {
         extendRoutes (routes) {
           routes.push({ path: '/about', redirect: '/about-us' })
-          routes.push({ path: '/home', redirect: '' })
         }
       }
     }
@@ -152,12 +151,6 @@ describe('with redirect route', () => {
     const window = await nuxt.renderAndGetWindow(url('/about'))
     const newRoute = window.$nuxt.switchLocalePath('fr')
     expect(newRoute).toBe('/fr/a-propos')
-  })
-
-  test('an empty string redirect path goes to the localized root', async () => {
-    const window = await nuxt.renderAndGetWindow(url('/home'))
-    const newRoute = window.$nuxt.switchLocalePath('fr')
-    expect(newRoute).toBe('/fr')
   })
 })
 

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -126,13 +126,31 @@ describe('basic', () => {
     const newRoute = window.$nuxt.localePath('about')
     expect(newRoute).toBe('/about-us')
   })
+})
 
-  describe('redirect', () => {
-    test('localePath returns redirect path', async () => {
-      const window = await nuxt.renderAndGetWindow(url('/home'))
-      const newRoute = window.$nuxt.localePath('index')
-      expect(newRoute).toBe('/')
+describe('with redirect route', () => {
+  let nuxt
+
+  beforeAll(async () => {
+    const override = {
+      router: {
+        extendRoutes (routes) {
+          routes.push({ path: '/home', redirect: '/' })
+        }
+      }
+    }
+
+    afterAll(async () => {
+      await nuxt.close()
     })
+
+    nuxt = (await setup(loadConfig(__dirname, 'basic', override, { merge: true }))).nuxt
+  })
+
+  test('localePath returns redirect path', async () => {
+    const window = await nuxt.renderAndGetWindow(url('/home'))
+    const newRoute = window.$nuxt.localePath('index')
+    expect(newRoute).toBe('/')
   })
 })
 

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -126,6 +126,14 @@ describe('basic', () => {
     const newRoute = window.$nuxt.localePath('about')
     expect(newRoute).toBe('/about-us')
   })
+
+  describe('redirect', () => {
+    test('localePath returns redirect path', async () => {
+      const window = await nuxt.renderAndGetWindow(url('/home'))
+      const newRoute = window.$nuxt.localePath('index')
+      expect(newRoute).toBe('/')
+    })
+  })
 })
 
 describe('lazy loading', () => {

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -135,7 +135,8 @@ describe('with redirect route', () => {
     const override = {
       router: {
         extendRoutes (routes) {
-          routes.push({ path: '/home', redirect: '/' })
+          routes.push({ path: '/about', redirect: '/about-us' })
+          routes.push({ path: '/home', redirect: '' })
         }
       }
     }
@@ -148,9 +149,17 @@ describe('with redirect route', () => {
   })
 
   test('localePath returns redirect path', async () => {
+    const window = await nuxt.renderAndGetWindow(url('/about'))
+    window.$nuxt.switchLocalePath('fr')
+    const newRoute = window.$nuxt.localePath('about')
+    expect(newRoute).toBe('/fr/about-us')
+  })
+
+  test('an empty string redirect path goes to /fr', async () => {
     const window = await nuxt.renderAndGetWindow(url('/home'))
+    window.$nuxt.switchLocalePath('fr')
     const newRoute = window.$nuxt.localePath('index')
-    expect(newRoute).toBe('/')
+    expect(newRoute).toBe('/fr')
   })
 })
 

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -140,11 +140,11 @@ describe('with redirect route', () => {
       }
     }
 
-    afterAll(async () => {
-      await nuxt.close()
-    })
-
     nuxt = (await setup(loadConfig(__dirname, 'basic', override, { merge: true }))).nuxt
+  })
+
+  afterAll(async () => {
+    await nuxt.close()
   })
 
   test('localePath returns redirect path', async () => {

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -151,7 +151,7 @@ describe('with redirect route', () => {
   test('switchLocalePath returns redirected path', async () => {
     const window = await nuxt.renderAndGetWindow(url('/about'))
     const newRoute = window.$nuxt.switchLocalePath('fr')
-    expect(newRoute).toBe('/fr/about-us')
+    expect(newRoute).toBe('/fr/a-propos')
   })
 
   test('an empty string redirect path goes to the localized root', async () => {

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -9,7 +9,15 @@ describe('basic', () => {
   let nuxt
 
   beforeAll(async () => {
-    nuxt = (await setup(loadConfig(__dirname, 'basic'))).nuxt
+    const override = {
+      router: {
+        extendRoutes (routes) {
+          routes.push({ path: '/about', redirect: '/about-us' })
+        }
+      }
+    }
+
+    nuxt = (await setup(loadConfig(__dirname, 'basic', override, { merge: true }))).nuxt
   })
 
   afterAll(async () => {
@@ -126,31 +134,11 @@ describe('basic', () => {
     const newRoute = window.$nuxt.localePath('about')
     expect(newRoute).toBe('/about-us')
   })
-})
 
-describe('with redirect route', () => {
-  let nuxt
-
-  beforeAll(async () => {
-    const override = {
-      router: {
-        extendRoutes (routes) {
-          routes.push({ path: '/about', redirect: '/about-us' })
-        }
-      }
-    }
-
-    nuxt = (await setup(loadConfig(__dirname, 'basic', override, { merge: true }))).nuxt
-  })
-
-  afterAll(async () => {
-    await nuxt.close()
-  })
-
-  test('switchLocalePath returns redirected path', async () => {
+  test('redirects to existing route', async () => {
     const window = await nuxt.renderAndGetWindow(url('/about'))
-    const newRoute = window.$nuxt.switchLocalePath('fr')
-    expect(newRoute).toBe('/fr/a-propos')
+    const newRoute = window.$nuxt.switchLocalePath()
+    expect(newRoute).toBe('/about-us')
   })
 })
 

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -148,17 +148,15 @@ describe('with redirect route', () => {
     await nuxt.close()
   })
 
-  test('localePath returns redirect path', async () => {
+  test('switchLocalePath returns redirected path', async () => {
     const window = await nuxt.renderAndGetWindow(url('/about'))
-    window.$nuxt.switchLocalePath('fr')
-    const newRoute = window.$nuxt.localePath('about')
+    const newRoute = window.$nuxt.switchLocalePath('fr')
     expect(newRoute).toBe('/fr/about-us')
   })
 
-  test('an empty string redirect path goes to /fr', async () => {
+  test('an empty string redirect path goes to the localized root', async () => {
     const window = await nuxt.renderAndGetWindow(url('/home'))
-    window.$nuxt.switchLocalePath('fr')
-    const newRoute = window.$nuxt.localePath('index')
+    const newRoute = window.$nuxt.switchLocalePath('fr')
     expect(newRoute).toBe('/fr')
   })
 })


### PR DESCRIPTION
This prevents the page parser from crashing when there are routes which have no component. (Eg  [redirect paths](https://router.vuejs.org/guide/essentials/redirect-and-alias.html#redirect))

I'm unsure if further work is be needed to localize these redirect paths or not.