### PR TITLE
fix: crash on no_prefix + invalid/tempered locale cookie

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -36,7 +36,7 @@ exports.DEFAULT_OPTIONS = {
   detectBrowserLanguage: {
     useCookie: true,
     cookieKey: 'i18n_redirected',
-    alwaysRedirect: '',
+    alwaysRedirect: false,
     fallbackLocale: null
   },
   differentDomains: false,

--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -203,7 +203,11 @@ export default async (context) => {
     const routeLocale = getLocaleFromRoute(route)
     locale = routeLocale || locale
   } else if (useCookie) {
-    locale = getLocaleCookie() || locale
+    const localeCookie = getLocaleCookie()
+
+    if (localeCodes.includes(localeCookie)) {
+      locale = localeCookie
+    }
   }
 
   await loadAndSetLocale(locale, { initialSetup: true })

--- a/test/__snapshots__/module.test.js.snap
+++ b/test/__snapshots__/module.test.js.snap
@@ -150,7 +150,7 @@ exports[`no_prefix strategy / contains EN text & link /about 1`] = `
   <body >
     <div data-server-rendered=\\"true\\" id=\\"__nuxt\\"><!----><div id=\\"__layout\\"><div>
   Homepage
-  <a href=\\"/about\\">About us</a></div></div></div>
+  <a href=\\"/about\\">About us</a> <div>locale: en</div></div></div></div>
   </body>
 </html>
 "

--- a/test/fixture/no-lang-switcher/pages/index.vue
+++ b/test/fixture/no-lang-switcher/pages/index.vue
@@ -2,5 +2,6 @@
 <div>
   {{ $t('home') }}
   <nuxt-link exact :to="localePath('about')">{{ $t('about') }}</nuxt-link>
+  <div>locale: {{ $i18n.locale }}</div>
 </div>
 </template>

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -140,6 +140,16 @@ describe('basic', () => {
     const newRoute = window.$nuxt.switchLocalePath()
     expect(newRoute).toBe('/about-us')
   })
+
+  test('fallbacks to default locale with invalid locale cookie', async () => {
+    const requestOptions = {
+      headers: {
+        Cookie: 'i18n_redirected=invalid'
+      }
+    }
+    const html = await get('/', requestOptions)
+    expect(cleanUpScripts(html)).toContain('locale: en')
+  })
 })
 
 describe('lazy loading', () => {
@@ -254,6 +264,16 @@ describe('no_prefix strategy', () => {
     expect(newRoute).toBe('/about')
 
     spy.mockRestore()
+  })
+
+  test('fallbacks to default locale with invalid locale cookie', async () => {
+    const requestOptions = {
+      headers: {
+        Cookie: 'i18n_redirected=invalid'
+      }
+    }
+    const html = await get('/', requestOptions)
+    expect(cleanUpScripts(html)).toContain('locale: en')
   })
 })
 


### PR DESCRIPTION
We need to validate locale gotten from cookie as invalid one would
later crash when creating SEO tags. And it's not useful to have invalid
locale set.