### PR TITLE
fix: NO_PREFIX - localePath with `path` returns route with prefix

### DIFF
--- a/src/plugins/routing.js
+++ b/src/plugins/routing.js
@@ -41,7 +41,7 @@ function localePathFactory (i18nPath, routerPath) {
         // don't prefix default locale
         !(locale === defaultLocale && strategy === STRATEGIES.PREFIX_EXCEPT_DEFAULT) &&
         // no prefix for any language
-        !(strategy === STRATEGIES.NO_REFIX) &&
+        !(strategy === STRATEGIES.NO_PREFIX) &&
         // no prefix for different domains
         !i18n.differentDomains
       )

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -131,8 +131,10 @@ describe('basic', () => {
 
   test('localePath returns correct path', async () => {
     const window = await nuxt.renderAndGetWindow(url('/'))
-    const newRoute = window.$nuxt.localePath('about')
-    expect(newRoute).toBe('/about-us')
+    expect(window.$nuxt.localePath('about')).toBe('/about-us')
+    expect(window.$nuxt.localePath('about', 'fr')).toBe('/fr/a-propos')
+    expect(window.$nuxt.localePath({ path: '/about' })).toBe('/about-us')
+    expect(window.$nuxt.localePath({ path: '/about/' })).toBe('/about-us')
   })
 
   test('redirects to existing route', async () => {
@@ -250,8 +252,8 @@ describe('no_prefix strategy', () => {
 
   test('localePath returns correct path', async () => {
     const window = await nuxt.renderAndGetWindow(url('/'))
-    const newRoute = window.$nuxt.localePath('about')
-    expect(newRoute).toBe('/about')
+    expect(window.$nuxt.localePath('about')).toBe('/about')
+    expect(window.$nuxt.localePath({ path: '/about' })).toBe('/about')
   })
 
   test('localePath with non-current locale triggers warning', async () => {


### PR DESCRIPTION
The case that was wrong was when calling `localePath` with
`{ path: '/about' }` argument when strategy was NO_PREFIX. Code
has prefixed result with a locale while it never should.

Case when passing component name to `localePath` was not affected
by the bug.