### PR TITLE
fix: Route name missing for routes with children + Locale prefixes missing for child routes with custom paths

### DIFF
--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -72,12 +72,13 @@ exports.makeRoutes = (baseRoutes, {
         continue
       }
 
-      // Make localized route name
-      localizedRoute.name = name + routesNameSeparator + locale
+      // Make localized route name. Name might not exist on parent route if child has same path.
+      if (name) {
+        localizedRoute.name = name + routesNameSeparator + locale
+      }
 
       // Generate localized children routes if any
       if (route.children) {
-        delete localizedRoute.name
         localizedRoute.children = []
         for (let i = 0, length1 = route.children.length; i < length1; i++) {
           localizedRoute.children = localizedRoute.children.concat(buildLocalizedRoutes(route.children[i], { locales: [locale] }, true, isExtraRouteTree))
@@ -96,10 +97,11 @@ exports.makeRoutes = (baseRoutes, {
         if (!isChild) {
           const defaultRoute = { ...localizedRoute, path }
 
-          // Only routes without children have name
-          if (!defaultRoute.children) {
+          if (name) {
             defaultRoute.name = localizedRoute.name + routesNameSeparator + defaultLocaleRouteNameSuffix
-          } else {
+          }
+
+          if (defaultRoute.children) {
             // Recreate child routes with default suffix added
             defaultRoute.children = []
             for (const childRoute of route.children) {
@@ -109,7 +111,7 @@ exports.makeRoutes = (baseRoutes, {
           }
 
           routes.push(defaultRoute)
-        } else if (isChild && isExtraRouteTree) {
+        } else if (isChild && isExtraRouteTree && name) {
           localizedRoute.name += routesNameSeparator + defaultLocaleRouteNameSuffix
         }
       }

--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -116,12 +116,14 @@ exports.makeRoutes = (baseRoutes, {
         }
       }
 
+      const isChildWithRelativePath = isChild && !path.startsWith('/')
+
       // Add route prefix if needed
       const shouldAddPrefix = (
         // No prefix if app uses different locale domains
         !differentDomains &&
-        // Only add prefix on top level routes
-        !isChild &&
+        // No need to add prefix if child's path is relative
+        !isChildWithRelativePath &&
         // Skip default locale if strategy is PREFIX_EXCEPT_DEFAULT
         !(locale === defaultLocale && strategy === STRATEGIES.PREFIX_EXCEPT_DEFAULT)
       )

--- a/test/fixture/basic/pages/posts/index.vue
+++ b/test/fixture/basic/pages/posts/index.vue
@@ -1,19 +1,19 @@
 <template>
-<div>
-  <nuxt-link
-    exact
-    :to="localePath({
-      name: 'posts-slug',
-      params: {
-        slug: params[$i18n.locale].slug
-      }
-    })">{{ params[$i18n.locale].slug }}</nuxt-link>
-</div>
+  <div>
+    <nuxt-link
+      exact
+      :to="localePath({
+        name: 'posts-slug',
+        params: {
+          slug: params[$i18n.locale].slug
+        }
+      })">{{ params[$i18n.locale].slug }}</nuxt-link>
+  </div>
 </template>
 
 <script>
 export default {
-  async asyncData () {
+  data () {
     return {
       params: {
         en: { slug: 'my-post' },

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -137,6 +137,15 @@ describe('basic', () => {
     })
   })
 
+  test('navigates to child route with nameless parent and checks path to other locale', async () => {
+    const window = await nuxt.renderAndGetWindow(url('/posts'))
+
+    const links = window.document.querySelectorAll('a')
+    expect(links.length).toBe(2)
+    expect(links[0].getAttribute('href')).toEqual('/fr/articles/')
+    expect(links[1].getAttribute('href')).toEqual('/posts/my-post')
+  })
+
   test('navigates to dynamic child route and checks path to other locale', async () => {
     const window = await nuxt.renderAndGetWindow(url('/dynamicNested/1'))
 

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -137,6 +137,17 @@ describe('basic', () => {
     })
   })
 
+  test('navigates to dynamic child route and checks path to other locale', async () => {
+    const window = await nuxt.renderAndGetWindow(url('/dynamicNested/1'))
+
+    const body = window.document.querySelector('body')
+    expect(body.textContent).toContain('Category')
+    expect(body.textContent).not.toContain('Subcategory')
+
+    // Will only work if navigated-to route has a name.
+    expect(window.$nuxt.switchLocalePath('fr')).toBe('/fr/imbrication-dynamique/1')
+  })
+
   test('/dynamicNested/1/2/3 contains link to /fr/imbrication-dynamique/1/2/3', async () => {
     const html = await get('/dynamicNested/1/2/3')
     expect(cleanUpScripts(html)).toMatchSnapshot()

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -256,6 +256,43 @@ describe('with empty configuration', () => {
   })
 })
 
+describe('prefix_and_default strategy', () => {
+  let nuxt
+
+  beforeAll(async () => {
+    const override = { i18n: { strategy: 'prefix_and_default' } }
+    nuxt = (await setup(loadConfig(__dirname, 'basic', override, { merge: true }))).nuxt
+  })
+
+  afterAll(async () => {
+    await nuxt.close()
+  })
+
+  test('default locale routes / and /en exist', async () => {
+    await expect(get('/')).resolves.toContain('page: Homepage')
+    await expect(get('/en')).resolves.toContain('page: Homepage')
+  })
+
+  test('non-default locale route /fr exists', async () => {
+    await expect(get('/fr')).resolves.toContain('page: Accueil')
+  })
+
+  test('canonical SEO link is added to prefixed default locale', async () => {
+    const html = await get('/en')
+    const dom = getDom(html)
+    const links = dom.querySelectorAll('head link[rel="canonical"]')
+    expect(links.length).toBe(1)
+    expect(links[0].getAttribute('href')).toBe('nuxt-app.localhost/')
+  })
+
+  test('canonical SEO link is not added to non-prefixed default locale', async () => {
+    const html = await get('/')
+    const dom = getDom(html)
+    const links = dom.querySelectorAll('head link[rel="canonical"]')
+    expect(links.length).toBe(0)
+  })
+})
+
 describe('no_prefix strategy', () => {
   let nuxt
 


### PR DESCRIPTION
PR includes two separate (but in the same family) bugs, in two separate commits.
Refer to individual commits messages for more info.

Resolves #356, #359