### PR TITLE
chore(docs): Remove note about need for maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,6 @@
 </a>
 </p>
 
-<h2 align="center">Co-maintainers welcome!</h2>
-
-I've been lacking time to properly maintain the project lately and I would be really happy if anyone were interested in helping me maintaining **nuxt-i18n**! It looks like there are more and more projects using this module and we've had great contributions from the community. It's just getting hard to keep track of the issues and questions here and on CMTY so don't hesitate to get in touch if you're interested in taking a bigger part in the project!
-
-Feel free to email me at the address that's in [my profile](https://github.com/paulgv).
-
 ## Contribute to the module
 
 - Fork the project and clone it in your existing Nuxt project:


### PR DESCRIPTION
That's because for some users it's concerning to read the note - they
think the module is not maintained while currently at least it is. :)