### PR TITLE
refactor: avoid storing route in a property

### DIFF
--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -161,7 +161,9 @@ export default async (context) => {
     await syncVuex(store, newLocale, app.i18n.getLocaleMessage(newLocale))
 
     if (!initialSetup && strategy !== STRATEGIES.NO_PREFIX) {
-      const route = app.i18n.__route
+      // Must retrieve from context as it might have changed since plugin initialization.
+      const { route } = context
+
       const routeName = route && route.name ? app.getRouteBaseName(route) : 'index'
       const redirectPath = app.localePath(Object.assign({}, route, { name: routeName }), newLocale)
 
@@ -182,9 +184,6 @@ export default async (context) => {
   app.i18n.setLocaleCookie = setLocaleCookie
   app.i18n.getLocaleCookie = getLocaleCookie
   app.i18n.setLocale = (locale) => loadAndSetLocale(locale)
-
-  // Current route. Updated from middleware also.
-  app.i18n.__route = route
 
   // Inject seo function
   Vue.prototype.$nuxtI18nSeo = nuxtI18nSeo
@@ -218,7 +217,7 @@ export default async (context) => {
 
   await loadAndSetLocale(locale, { initialSetup: true })
 
-  app.i18n.__detectBrowserLanguage = async route => {
+  app.i18n.__detectBrowserLanguage = async () => {
     if (detectBrowserLanguage) {
       const { alwaysRedirect, fallbackLocale } = detectBrowserLanguage
 
@@ -261,5 +260,5 @@ export default async (context) => {
     return false
   }
 
-  await app.i18n.__detectBrowserLanguage(route)
+  await app.i18n.__detectBrowserLanguage()
 }

--- a/src/templates/middleware.js
+++ b/src/templates/middleware.js
@@ -15,10 +15,7 @@ middleware.i18n = async (context) => {
     return
   }
 
-  // Update for setLocale to have up to date route
-  app.i18n.__route = route
-
-  if (detectBrowserLanguage && await app.i18n.__detectBrowserLanguage(route)) {
+  if (detectBrowserLanguage && await app.i18n.__detectBrowserLanguage()) {
     return
   }
 


### PR DESCRIPTION
I didn't realize that fact when creating __route property, but the
context object stays the same during lifetime of the application and
the `route` property is updated to match current route so we can use
that instead of creating extra from middleware.