### PR TITLE
Add warning for wildcards with prefix_except_default strategy

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -56,6 +56,10 @@ This strategy doesn't support [Custom paths](#custom-paths) and [Ignore routes](
 
 Using this strategy, all of your routes will have a locale prefix added except for the default language.
 
+::: warning
+For wildcard routes to work the order of locales in you config is important, the defaultLocale (without prefix) should be last.
+:::
+
 ### prefix
 
 With this strategy, all routes will have a locale prefix.


### PR DESCRIPTION
Let me know if this is the correct way of documenting this behaviour, but it took me a few hours to figure this out, and I hope I can prevent that wasted time for someone else.