### PR TITLE
fix: set sameSite=Lax option for detected-language cookie

### DIFF
--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -98,21 +98,20 @@ export default async (context) => {
       return
     }
     const date = new Date()
+    const cookieOptions = {
+      expires: new Date(date.setDate(date.getDate() + 365)),
+      path: '/',
+      sameSite: 'lax'
+    }
     if (process.client) {
-      JsCookie.set(cookieKey, locale, {
-        expires: new Date(date.setDate(date.getDate() + 365)),
-        path: '/'
-      })
+      JsCookie.set(cookieKey, locale, cookieOptions)
     } else if (res) {
       let headers = res.getHeader('Set-Cookie') || []
       if (typeof headers === 'string') {
         headers = [headers]
       }
 
-      const redirectCookie = Cookie.serialize(cookieKey, locale, {
-        expires: new Date(date.setDate(date.getDate() + 365)),
-        path: '/'
-      })
+      const redirectCookie = Cookie.serialize(cookieKey, locale, cookieOptions)
       headers.push(redirectCookie)
 
       res.setHeader('Set-Cookie', headers)


### PR DESCRIPTION
Avoids warnings triggered by browsers related to cookie not having
sameSite attribute.

More details at https://web.dev/samesite-cookies-explained/

Resolves #516