### PR TITLE
fix: default locale catch-all route overrides locale-specific one

### DIFF
--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -1,6 +1,4 @@
-const {
-  STRATEGIES
-} = require('./constants')
+const { STRATEGIES } = require('./constants')
 const { extractComponentOptions } = require('./components')
 const { getPageOptions, getLocaleCodes } = require('./utils')
 
@@ -135,6 +133,13 @@ exports.makeRoutes = (baseRoutes, {
   for (let i = 0, length1 = baseRoutes.length; i < length1; i++) {
     const route = baseRoutes[i]
     localizedRoutes = localizedRoutes.concat(buildLocalizedRoutes(route, { locales }))
+  }
+
+  try {
+    const { sortRoutes } = require('@nuxt/utils')
+    localizedRoutes = sortRoutes(localizedRoutes)
+  } catch (error) {
+    // Ignore
   }
 
   return localizedRoutes

--- a/test/fixture/dynamic/nuxt.config.js
+++ b/test/fixture/dynamic/nuxt.config.js
@@ -1,0 +1,7 @@
+const { resolve } = require('path')
+
+module.exports = {
+  ...require('../base.config.js'),
+  buildDir: resolve(__dirname, '.nuxt'),
+  srcDir: __dirname
+}

--- a/test/fixture/dynamic/pages/_.vue
+++ b/test/fixture/dynamic/pages/_.vue
@@ -1,0 +1,9 @@
+<template>
+  <div>
+    <div id="current-locale">locale: {{ $i18n.locale }}</div>
+  </div>
+</template>
+
+<script>
+export default {}
+</script>

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -569,6 +569,28 @@ describe('invalid strategy', () => {
   })
 })
 
+describe('dynamic route', () => {
+  let nuxt
+
+  beforeAll(async () => {
+    nuxt = (await setup(loadConfig(__dirname, 'dynamic'))).nuxt
+  })
+
+  afterAll(async () => {
+    await nuxt.close()
+  })
+
+  test('can access catch-all route for every locale', async () => {
+    let html = await get('/aaa')
+    let dom = getDom(html)
+    expect(dom.querySelector('#current-locale').textContent).toBe('locale: en')
+
+    html = await get('/fr/aaa')
+    dom = getDom(html)
+    expect(dom.querySelector('#current-locale').textContent).toBe('locale: fr')
+  })
+})
+
 describe('hash mode', () => {
   let nuxt
 


### PR DESCRIPTION
With there being a catch-all route (_.vue) in pages directory,
depending on the order of locales in configuration, default locale's
route could shadow locale-specific one due to being first on the list
of generated routes. For example, routes were generated like so:

```
  routes: [{
    path: "/*",
    component: _0bdbeb02,
    name: "all___en"
  }, {
    path: "/fr/*",
    component: _0bdbeb02,
    name: "all___fr"
  }],
```

which meant that `/*` route never allowed later ones to be matched.

Fix by sorting routes by specificity, using function exposed
by `@nuxt/utils` (only from 2.10.2).

Resolves #152