### PR TITLE
refactor: change middleware key to avoid conflicts with other modules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -130,7 +130,7 @@ module.exports = function (userOptions) {
     })
   }
 
-  this.options.router.middleware.push('i18n')
+  this.options.router.middleware.push('nuxti18n')
   this.options.render.bundleRenderer.directives = this.options.render.bundleRenderer.directives || {}
   this.options.render.bundleRenderer.directives.t = i18nExtensions.directive
 }

--- a/src/templates/middleware.js
+++ b/src/templates/middleware.js
@@ -2,7 +2,7 @@ import middleware from '../middleware'
 import { detectBrowserLanguage, rootRedirect } from './options'
 import { getLocaleFromRoute } from './utils'
 
-middleware.i18n = async (context) => {
+middleware.nuxti18n = async (context) => {
   const { app, route, redirect, isHMR } = context
 
   if (isHMR) {


### PR DESCRIPTION
resolves #531 

there are not functional/breaking changes. Generally adding middleware by module is tricky and I didn't see good practices how we should do it, but we can make sure we don't conflict with other modules. 