### PR TITLE
fix(routing): Restore handling of route argument in getRouteBaseName

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -47,7 +47,7 @@ In `no_prefix` strategy, passing `locale` other than the current one is not supp
 #### getRouteBaseName
 
   - **Arguments**:
-    - route (type: `string` | [`Location`](https://github.com/vuejs/vue-router/blob/f40139c27a9736efcbda69ec136cb00d8e00fa97/types/router.d.ts#L125), default: current route)
+    - route (type: `Route`(https://github.com/vuejs/vue-router/blob/f40139c27a9736efcbda69ec136cb00d8e00fa97/types/router.d.ts#L135), default: current route)
   - **Returns**: `string`
 
   Returns base name of current (if argument not provided) or passed in `route`. Base name is name of the route without locale suffix and other metadata added by `nuxt-i18n`.

--- a/src/plugins/routing.js
+++ b/src/plugins/routing.js
@@ -120,8 +120,8 @@ function switchLocalePath (locale) {
   return path
 }
 
-function getRouteBaseName () {
-  const { route } = this
+function getRouteBaseName (givenRoute) {
+  const route = givenRoute || this.route
   if (!route.name) {
     return null
   }

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -280,6 +280,14 @@ describe('basic', () => {
     expect(window.$nuxt.getRouteBaseName()).toBe('index')
   })
 
+  test('getRouteBaseName returns name of passed in route', async () => {
+    const window = await nuxt.renderAndGetWindow(url('/'))
+    const aboutRoute = window.$nuxt.$router.options.routes.find(route => route.path === '/about-us')
+    expect(aboutRoute).toBeDefined()
+    expect(aboutRoute.name).toBeDefined()
+    expect(window.$nuxt.getRouteBaseName(aboutRoute)).toBe('about')
+  })
+
   test('localePath, switchLocalePath, getRouteBaseName works from a middleware', async () => {
     const html = await get('/middleware')
     const dom = getDom(html)

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import { RawLocation } from 'vue-router'
+import { RawLocation, Route } from 'vue-router'
 import VueI18n, { IVueI18n } from 'vue-i18n'
 import { MetaInfo } from 'vue-meta'
 import { NuxtI18nComponentOptions, NuxtVueI18n, NuxtI18nSeo } from './nuxt-i18n'
@@ -24,7 +24,7 @@ declare module 'vue/types/vue' {
   interface Vue {
     localePath(route: RawLocation, locale?: string): string
     switchLocalePath(locale: string): string
-    getRouteBaseName(route?: RawLocation): string
+    getRouteBaseName(route?: Route): string
     $nuxtI18nSeo(): NuxtI18nSeo
     // PHPStorm without this indicates that "$i18n" was not found.
     readonly $i18n: VueI18n & IVueI18n


### PR DESCRIPTION
In 8a1c052f340ad8f86d62fb1e3c6f1107360fb0e9 the functionality to pass
route to `getRouteBaseName` was accidentally removed. Bring that back
and update documentation to state what's the actual argument. It was
incorrectly specifying `string | Location` as argument while
currently it has to be a `Route`.

Resolves #539