### PR TITLE
fix: remove substring to support localCode more than 2 digits

### DIFF
--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -233,9 +233,9 @@ export default async (context) => {
         // Exclude 1 for backwards compatibility and fallback when fallbackLocale is empty
       } else if (process.client && typeof navigator !== 'undefined' && navigator.language) {
         // Get browser language either from navigator if running on client side, or from the headers
-        browserLocale = navigator.language.toLocaleLowerCase().substring(0, 2)
+        browserLocale = navigator.language.toLocaleLowerCase()
       } else if (req && typeof req.headers['accept-language'] !== 'undefined') {
-        browserLocale = req.headers['accept-language'].split(',')[0].toLocaleLowerCase().substring(0, 2)
+        browserLocale = req.headers['accept-language'].split(',')[0].toLocaleLowerCase()
       }
 
       if (browserLocale) {


### PR DESCRIPTION
`localeCodes` is defined in `nuxt.config.js`, so we don't need to trim the locale code to 2 digits.
Otherwise, the detected language would be wrong if the locale code has more than 2 digit.

For example: `zh-TW` and `zh-CN` are totally two different charsets. If it's still limited to 2 digits, there is no way to distinguish from them.