### PR TITLE
chore(deps): migrate vue-i18n-loader package name

### DIFF
--- a/docs/es/vue-i18n-loader.md
+++ b/docs/es/vue-i18n-loader.md
@@ -1,6 +1,6 @@
 # vue-i18n-loader
 
-Si desea habilitar [vue-i18n-loader](https://github.com/kazupon/vue-i18n-loader), simplemente configure la opción `vueI18nLoader` en `true`.
+Si desea habilitar [vue-i18n-loader](https://github.com/intlify/vue-i18n-loader), simplemente configure la opción `vueI18nLoader` en `true`.
 
 ```js
 // nuxt.config.js
@@ -53,7 +53,7 @@ build: {
     config.module.rules.push({
       resourceQuery: /blockType=i18n/,
       type: "javascript/auto",
-      loader: ["@kazupon/vue-i18n-loader", "yaml-loader"],
+      loader: ["@intlify/vue-i18n-loader", "yaml-loader"],
     });
   },
 }

--- a/docs/es/vue-i18n-loader.md
+++ b/docs/es/vue-i18n-loader.md
@@ -33,7 +33,7 @@ Ahora puede definir traducciones utilizando bloques personalizados en sus archiv
 ## YAML
 
 ```vue
-<i18n>
+<i18n lang="yaml">
 en:
   hello: "hello world!"
 ja:
@@ -43,18 +43,4 @@ ja:
 <template>
  <p>{{ $t('hello') }}</p>
 </template>
-```
-
-Lo siguiente es necesario en el archivo de configuración nuxt para que funcionen los bloques YAML i18n:
-
-```js
-build: {
-  extend(config) {
-    config.module.rules.push({
-      resourceQuery: /blockType=i18n/,
-      type: "javascript/auto",
-      loader: ["@intlify/vue-i18n-loader", "yaml-loader"],
-    });
-  },
-}
 ```

--- a/docs/vue-i18n-loader.md
+++ b/docs/vue-i18n-loader.md
@@ -1,6 +1,6 @@
 # vue-i18n-loader
 
-If you'd like to enable [vue-i18n-loader](https://github.com/kazupon/vue-i18n-loader), simply set `vueI18nLoader` option to `true`.
+If you'd like to enable [vue-i18n-loader](https://github.com/intlify/vue-i18n-loader), simply set `vueI18nLoader` option to `true`.
 
 ```js
 // nuxt.config.js
@@ -53,7 +53,7 @@ build: {
     config.module.rules.push({
       resourceQuery: /blockType=i18n/,
       type: "javascript/auto",
-      loader: ["@kazupon/vue-i18n-loader", "yaml-loader"],
+      loader: ["@intlify/vue-i18n-loader", "yaml-loader"],
     });
   },
 }

--- a/docs/vue-i18n-loader.md
+++ b/docs/vue-i18n-loader.md
@@ -33,7 +33,7 @@ You can now define translations using custom blocks in your Vue files:
 ## YAML
 
 ```vue
-<i18n>
+<i18n lang="yaml">
 en:
   hello: "hello world!"
 ja:
@@ -43,18 +43,4 @@ ja:
 <template>
  <p>{{ $t('hello') }}</p>
 </template>
-```
-
-The following is needed in nuxt config file for YAML i18n blocks to work:
-
-```js
-build: {
-  extend(config) {
-    config.module.rules.push({
-      resourceQuery: /blockType=i18n/,
-      type: "javascript/auto",
-      loader: ["@intlify/vue-i18n-loader", "yaml-loader"],
-    });
-  },
-}
 ```

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@babel/parser": "^7.5.5",
     "@babel/traverse": "^7.5.5",
-    "@kazupon/vue-i18n-loader": "^0.5.0",
+    "@intlify/vue-i18n-loader": "^0.6.1",
     "cookie": "^0.4.0",
     "is-https": "^1.0.0",
     "js-cookie": "^2.2.1",

--- a/src/index.js
+++ b/src/index.js
@@ -118,13 +118,13 @@ module.exports = function (userOptions) {
       if (loaders) {
         // vue-loader under 15.0.0
         /* istanbul ignore next */
-        loaders.i18n = '@kazupon/vue-i18n-loader'
+        loaders.i18n = '@intlify/vue-i18n-loader'
       } else {
         // vue-loader after 15.0.0
         config.module.rules.push({
           resourceQuery: /blockType=i18n/,
           type: 'javascript/auto',
-          loader: '@kazupon/vue-i18n-loader'
+          loader: '@intlify/vue-i18n-loader'
         })
       }
     })

--- a/test/fixture/basic/pages/loader-yaml.vue
+++ b/test/fixture/basic/pages/loader-yaml.vue
@@ -1,0 +1,10 @@
+<template>
+  <p>{{ $t('hello') }}</p>
+</template>
+
+<i18n lang="yaml">
+en:
+  hello: "hello world!"
+fr:
+  hello: "Bonjour le monde!"
+</i18n>

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -328,6 +328,18 @@ describe('basic', () => {
     const dom = getDom(html)
     expect(dom.querySelector('#container').textContent).toBe('string from loader EN')
   })
+
+  test('registers message using vueI18nLoader from yaml block', async () => {
+    let html = await get('/loader-yaml')
+    let dom = getDom(html)
+    let title = dom.querySelector('p')
+    expect(title.textContent).toBe('hello world!')
+
+    html = await get('/fr/loader-yaml')
+    dom = getDom(html)
+    title = dom.querySelector('p')
+    expect(title.textContent).toBe('Bonjour le monde!')
+  })
 })
 
 describe('hreflang', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -850,6 +850,14 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@intlify/vue-i18n-loader@^0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@intlify/vue-i18n-loader/-/vue-i18n-loader-0.6.1.tgz#dbf7ab1d7ea3641396733b9827fed949644b1eeb"
+  integrity sha512-PyBeKrIxNQmnHq/hYGMneVIQAlGTWsFu92SMD5Noyi3GcHJvDpnthWTuRUBAsY4WqQ7RYLCnrngqCrUY5tNZtg==
+  dependencies:
+    js-yaml "^3.13.1"
+    json5 "^2.1.1"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz#10602de5570baea82f8afbfa2630b24e7a8cfe5b"
@@ -1023,14 +1031,6 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
-
-"@kazupon/vue-i18n-loader@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@kazupon/vue-i18n-loader/-/vue-i18n-loader-0.5.0.tgz#64819fc9dbe21bac523e3436b7e15c32bcd33b92"
-  integrity sha512-Tp2mXKemf9/RBhI9CW14JjR9oKjL2KH7tV6S0eKEjIBuQBAOFNuPJu3ouacmz9hgoXbNp+nusw3MVQmxZWFR9g==
-  dependencies:
-    js-yaml "^3.13.1"
-    json5 "^2.1.1"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"


### PR DESCRIPTION
Hello. Thank you for awesome package :)

The vue-i18n-loader package name & repo has been changed. Please see the following.

> https://github.com/intlify/vue-i18n-loader/pull/69/.

This PR update following.

* dependency
* docs
* loader in `index.js`