### PR TITLE
fix: use the synced locale on client if set during SSR

### DIFF
--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -206,7 +206,9 @@ export default async (context) => {
 
   let locale = app.i18n.defaultLocale || null
 
-  if (app.i18n.differentDomains) {
+  if (vuex && vuex.syncLocale && store && store.state[vuex.moduleName].locale !== '') {
+    locale = store.state[vuex.moduleName].locale
+  } else if (app.i18n.differentDomains) {
     const domainLocale = getLocaleDomain(app.i18n, req)
     locale = domainLocale || locale
   } else if (strategy !== STRATEGIES.NO_PREFIX) {


### PR DESCRIPTION
If `vuex.syncLocale` is true, then any locale determined on the server during SSR should be used as initial value by the client.

This also allows:
- Not to determine the language twice when a page is loaded (once on the server, then again in the client)
- Other plugins (e.g. user session in a universal app) to alter the locale during bootstrap (`await app.i18n.setLocale('xx')`) and make sure that that locale is re-used on the client.

Note that I think that this should be default behavior for this module.