### PR TITLE
Fix bug 'cannot read property req of undefined'

### DIFF
--- a/src/plugins/routing.js
+++ b/src/plugins/routing.js
@@ -140,7 +140,7 @@ const VueInstanceProxy = function (targetFunction) {
       getRouteBaseName: this.getRouteBaseName,
       i18n: this.$i18n,
       localePath: this.localePath,
-      req: process.server ? this.$ssrContext.req : null,
+      req: process.server ? (this.$ssrContext || this.ssrContext || {}).req : null,
       route: this.$route,
       router: this.$router,
       store: this.$store


### PR DESCRIPTION
Hi guys!
Recently I've been getting error 'cannot read property req of undefined' on pages other than index. After some research I found the error appearing only during server side rendering with seo option enabled and coming from this line (don't actually know what it does with the routing plugin). I am using nuxt v2.10.2 and don't know if this is recent change, or not. But in context (`this`) I am not getting `$ssrContext`, but `ssrContext`. This quick fix is removing the error, while preserving the compatibility with the other versions and ensuring that page will work event without ssrContext (sadly, full webapp went completely broken after entering any of the problematic pages).