### PR TITLE
fix: Incomplete initialization with 'en-US' locale code and no default

### DIFF
--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -184,7 +184,11 @@ export default async (context) => {
   }
 
   // Set instance options
-  app.i18n = new VueI18n(typeof vueI18n === 'function' ? vueI18n(context) : vueI18n)
+  const vueI18nOptions = typeof vueI18n === 'function' ? vueI18n(context) : vueI18n
+  app.i18n = new VueI18n(vueI18nOptions)
+  // Initialize locale and fallbackLocale as vue-i18n defaults those to 'en-US' if falsey
+  app.i18n.locale = null
+  app.i18n.fallbackLocale = vueI18nOptions.fallbackLocale || null
   app.i18n.locales = locales
   app.i18n.defaultLocale = defaultLocale
   app.i18n.differentDomains = differentDomains

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -837,6 +837,50 @@ describe('differentDomains enabled', () => {
   })
 })
 
+// This is a special case due to vue-i18n defaulting to en-US for `defaultLocale`
+// and `fallbackLocale` which can prevent us from applying locale initially.
+describe('en-US locale with no explicit default locale (issue #628)', () => {
+  let nuxt
+
+  beforeAll(async () => {
+    const override = {
+      i18n: {
+        lazy: true,
+        langDir: 'lang/',
+        defaultLocale: null,
+        vueI18n: {
+          fallbackLocale: null,
+          messages: null
+        }
+      }
+    }
+
+    const localConfig = loadConfig(__dirname, 'basic', override, { merge: true })
+
+    // Override after merging options to avoid arrays being merged.
+    localConfig.i18n.locales = [
+      {
+        code: 'en-US',
+        iso: 'en-US',
+        name: 'English',
+        file: 'en-US.js'
+      }
+    ]
+
+    nuxt = (await setup(localConfig)).nuxt
+  })
+
+  afterAll(async () => {
+    await nuxt.close()
+  })
+
+  test('prefix is present and locale is applied', async () => {
+    const html = await get('/en-US')
+    const dom = getDom(html)
+    await expect(dom.querySelector('body').textContent).toContain('page: Homepage')
+  })
+})
+
 describe('external vue-i18n configuration', () => {
   let nuxt
 


### PR DESCRIPTION
When `defaultLocale` was not set, and there was locale with `en-US` code,
the code has failed to initialize locale (including failure to lazy-load lang
files) due to `newLocale === app.i18n.locale` check that returned true even
though we haven't fully initialized yet.

Resolves #628