### PR TITLE
Add vueI18nLoader to AllOptionsInterface of types

### DIFF
--- a/types/nuxt-i18n.d.ts
+++ b/types/nuxt-i18n.d.ts
@@ -69,6 +69,7 @@ declare namespace NuxtVueI18n {
       seo?: boolean
       strategy?: 'no_prefix' | 'prefix_except_default' | 'prefix' | 'prefix_and_default'
       vueI18n?: VueI18n.I18nOptions | string
+      vueI18nLoader?: boolean
       vuex?: VuexInterface | false
     }
   }


### PR DESCRIPTION
Add `vueI18nLoader` to `AllOptionsInterface` of types.
Because Options has `vueI18nLoader`.

https://nuxt-community.github.io/nuxt-i18n/options-reference.html