### PR TITLE
fix: locale not updated on navigation (no fallbackLocale)

### DIFF
--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -257,14 +257,12 @@ export default async (context) => {
 
           if (redirectToLocale && localeCodes.includes(redirectToLocale)) {
             if (redirectToLocale !== app.i18n.locale) {
-              // We switch the locale before redirect to prevent loops
               await app.i18n.setLocale(redirectToLocale)
+              return true
             } else if (useCookie && !getLocaleCookie()) {
               app.i18n.setLocaleCookie(redirectToLocale)
             }
           }
-
-          return true
         }
       }
     }


### PR DESCRIPTION
When:
 - `detectBrowserLanguage` was enabled
 - `detectBrowserLanguage.fallbackLocale` was not specified
 - preferred browser language was set to one that nuxt-i18n configuration
   didn't support

then navigating to another locale in SPA mode has updated the URL but
failed to change locale.

Fix by correcting the logic of browser language detection which was
supposed to return false when it didn't manage to detect language but
didn't always do that.

Resolves #643