### PR TITLE
feature: match against full language code provided by the browser

### DIFF
--- a/docs/browser-language-detection.md
+++ b/docs/browser-language-detection.md
@@ -6,6 +6,7 @@ By default, **nuxt-i18n** attempts to redirect users to their preferred language
 // nuxt.config.js
 
 ['nuxt-i18n', {
+  // ...
   detectBrowserLanguage: {
     useCookie: true,
     cookieKey: 'i18n_redirected'
@@ -14,7 +15,7 @@ By default, **nuxt-i18n** attempts to redirect users to their preferred language
 ```
 
 ::: tip
-Browser language is detected either from `navigator` if running on client side, or from the `accept-language` HTTP header. Moreover, only the first two characters of the language code are currently used. That means that there is no distinction between `en-AU` and `en-US`, for instance - they will be coalesced into just `en`.
+Browser language is detected either from `navigator` when running on client side, or from the `accept-language` HTTP header. Configured `locales` (or locales `code`s when locales are specified in object form) are matched against locales reported by the browser (for example `en-US,en;q=0.9,no;q=0.8`). If there is no exact match, the language code (letters before `-`) are matched against configured locales (for backwards compatibility).
 :::
 
 To prevent redirecting users every time they visit the app, **nuxt-i18n** sets a cookie after the first redirection. You can change the cookie's name by setting `detectBrowserLanguage.cookieKey` option to whatever you'd like, the default is _i18n_redirected_.
@@ -23,6 +24,7 @@ To prevent redirecting users every time they visit the app, **nuxt-i18n** sets a
 // nuxt.config.js
 
 ['nuxt-i18n', {
+  // ...
   detectBrowserLanguage: {
     useCookie: true,
     cookieKey: 'my_custom_cookie_name'
@@ -36,6 +38,7 @@ If you'd rather have users be redirected to their browser's language every time 
 // nuxt.config.js
 
 ['nuxt-i18n', {
+  // ...
   detectBrowserLanguage: {
     useCookie: false
   }
@@ -48,6 +51,7 @@ To completely disable the browser's language detection feature, set `detectBrows
 // nuxt.config.js
 
 ['nuxt-i18n', {
+  // ...
   detectBrowserLanguage: false
 }]
 ```
@@ -58,6 +62,7 @@ To redirect the user every time they visit the app and keep their selected choic
 // nuxt.config.js
 
 ['nuxt-i18n', {
+  // ...
   detectBrowserLanguage: {
     useCookie: true,
     alwaysRedirect: true

--- a/src/templates/utils-common.js
+++ b/src/templates/utils-common.js
@@ -1,0 +1,60 @@
+/**
+ * Parses locales provided from browser through `accept-language` header.
+ * @param {string} input
+ * @return {string[]} An array of locale codes. Priority determined by order in array.
+ **/
+export const parseAcceptLanguage = input => {
+  // Example input: en-US,en;q=0.9,nb;q=0.8,no;q=0.7
+  // Contains tags separated by comma.
+  // Each tag consists of locale code (2-3 letter language code) and optionally country code
+  // after dash. Tag can also contain score after semicolon, that is assumed to match order
+  // so it's not explicitly used.
+  return input.split(',').map(tag => tag.split(';')[0])
+}
+
+/**
+ * Find locale code that best matches provided list of browser locales.
+ * @param {string[]} appLocales The user-configured locale codes that are to be matched.
+ * @param {string[]} browserLocales The locales to match against configured.
+ * @return {string?}
+ **/
+export const matchBrowserLocale = (appLocales, browserLocales) => {
+  /** @type {{ code: string, score: number }[]} */
+  const matchedLocales = []
+
+  // First pass: match exact locale.
+  for (const [index, browserCode] of browserLocales.entries()) {
+    if (appLocales.includes(browserCode)) {
+      matchedLocales.push({ code: browserCode, score: 1 - index / browserLocales.length })
+      break
+    }
+  }
+
+  // Second pass: match only locale code part of the browser locale (not including country).
+  for (const [index, browserCode] of browserLocales.entries()) {
+    if (browserCode.includes('-')) {
+      // For backwards-compatibility, this is lower-cased before comparing.
+      const languageCode = browserCode.split('-')[0].toLowerCase()
+
+      if (appLocales.includes(languageCode)) {
+        // Deduct a thousandth for being non-exact match.
+        matchedLocales.push({ code: languageCode, score: 0.999 - index / browserLocales.length })
+        break
+      }
+    }
+  }
+
+  // Sort the list by score (0 - lowest, 1 - highest).
+  if (matchedLocales.length > 1) {
+    matchedLocales.sort((localeA, localeB) => {
+      if (localeA.score === localeB.score) {
+        // If scores are equal then pick more specific (longer) code.
+        return localeB.code.length - localeA.code.length
+      }
+
+      return localeB.score - localeA.score
+    })
+  }
+
+  return matchedLocales.length ? matchedLocales[0].code : null
+}

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -20,3 +20,79 @@ describe('parsePages', () => {
     expect(Object.keys(options).length).toBe(0)
   })
 })
+
+describe('parseAcceptLanguage', () => {
+  test('parses browser accept-language', async () => {
+    const { parseAcceptLanguage } = await import('../src/templates/utils-common')
+
+    expect(parseAcceptLanguage('en-US,en;q=0.9,nb;q=0.8,no;q=0.7')).toStrictEqual(['en-US', 'en', 'nb', 'no'])
+  })
+})
+
+describe('matchBrowserLocale', () => {
+  test('matches highest-ranked full locale', async () => {
+    const { matchBrowserLocale } = await import('../src/templates/utils-common')
+
+    // Both locales match first browser locale - full locale should win.
+    const appLocales = ['en', 'en-US']
+    const browserLocales = ['en-US', 'en']
+
+    expect(matchBrowserLocale(appLocales, browserLocales)).toBe('en-US')
+  })
+
+  test('matches highest-ranked short locale', async () => {
+    const { matchBrowserLocale } = await import('../src/templates/utils-common')
+
+    // Both locales match first browser locale - short locale should win.
+    // This is because browser locale order defines scoring so we prefer higher-scored over exact.
+    const appLocales = ['en', 'en-US']
+    const browserLocales = ['en', 'en-US']
+
+    expect(matchBrowserLocale(appLocales, browserLocales)).toBe('en')
+  })
+
+  test('matches highest-ranked short locale (only short defined)', async () => {
+    const { matchBrowserLocale } = await import('../src/templates/utils-common')
+
+    const appLocales = ['en']
+    const browserLocales = ['en-US', 'en']
+
+    expect(matchBrowserLocale(appLocales, browserLocales)).toBe('en')
+  })
+
+  test('matches highest-ranked short locale', async () => {
+    const { matchBrowserLocale } = await import('../src/templates/utils-common')
+
+    const appLocales = ['en', 'fr']
+    const browserLocales = ['en-US', 'en-GB']
+
+    expect(matchBrowserLocale(appLocales, browserLocales)).toBe('en')
+  })
+
+  test('does not match any locale', async () => {
+    const { matchBrowserLocale } = await import('../src/templates/utils-common')
+
+    const appLocales = ['pl', 'fr']
+    const browserLocales = ['en-US', 'en']
+
+    expect(matchBrowserLocale(appLocales, browserLocales)).toBe(null)
+  })
+
+  test('matches full locale with mixed short and full, full having highest rank', async () => {
+    const { matchBrowserLocale } = await import('../src/templates/utils-common')
+
+    const appLocales = ['en-US', 'en-GB', 'en']
+    const browserLocales = ['en-GB', 'en-US', 'en']
+
+    expect(matchBrowserLocale(appLocales, browserLocales)).toBe('en-GB')
+  })
+
+  test('matches short locale with mixed short and full, short having highest rank', async () => {
+    const { matchBrowserLocale } = await import('../src/templates/utils-common')
+
+    const appLocales = ['en-US', 'en-GB', 'en']
+    const browserLocales = ['en', 'en-GB', 'en-US']
+
+    expect(matchBrowserLocale(appLocales, browserLocales)).toBe('en')
+  })
+})


### PR DESCRIPTION
For detecting and redirecting to browser language the module only
looked at first two letters of the language codes provided by the
browser so it wasn't able to match up more specific locale codes like
en-GB or zh-CN.

Fix by matching checking against full language code first and then
falling back to only first two letters if no higher-ranked code
was found.

Resolves #650
Resolves #563