### PR TITLE
Update main.js

### DIFF
--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -255,6 +255,8 @@ export default async (context) => {
           localeCodes.forEach(localeCode => {
             if (browserLocale.includes(localeCode)) {
               redirectToLocale = localeCode
+            } else {
+              redirectToLocale = fallbackLocale
             }
           })
 

--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -255,6 +255,7 @@ export default async (context) => {
           localeCodes.forEach(localeCode => {
             if (browserLocale.includes(localeCode)) {
               redirectToLocale = localeCode
+              break
             } else {
               redirectToLocale = fallbackLocale
             }

--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -252,9 +252,12 @@ export default async (context) => {
 
           // Use localeCodes if browserLocale supports it, otherwise use fallbackLocale
           // localeCodes can be the suffix of locale identifier i.e. country/region code e.g. cn or tw in case of zh-*
-          if (browserLocale.includes(localeCodes)) {
-            redirectToLocale = localeCodes
-          }
+          localeCodes.forEach(localeCode => {
+            if (browserLocale.includes(localeCode)) {
+              redirectToLocale = localeCode
+              return
+            }
+          })
 
           if (redirectToLocale && localeCodes.includes(redirectToLocale)) {
             if (redirectToLocale !== app.i18n.locale) {

--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -252,13 +252,12 @@ export default async (context) => {
 
           // Use localeCodes if browserLocale supports it, otherwise use fallbackLocale
           // localeCodes can be the suffix of locale identifier i.e. country/region code e.g. cn or tw in case of zh-*
-          localeCodes.forEach(localeCode => {
+          localeCodes.some(localeCode => {
             if (browserLocale.includes(localeCode)) {
               redirectToLocale = localeCode
-              break
-            } else {
-              redirectToLocale = fallbackLocale
+              return true
             }
+            redirectToLocale = fallbackLocale
           })
 
           if (redirectToLocale && localeCodes.includes(redirectToLocale)) {

--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -255,7 +255,6 @@ export default async (context) => {
           localeCodes.forEach(localeCode => {
             if (browserLocale.includes(localeCode)) {
               redirectToLocale = localeCode
-              return
             }
           })
 

--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -252,7 +252,7 @@ export default async (context) => {
 
           // Use localeCodes if browserLocale supports it, otherwise use fallbackLocale
           // localeCodes can be the suffix of locale identifier i.e. country/region code e.g. cn or tw in case of zh-*
-          localeCodes.some(localeCode => {
+          localeCodes.forEach(localeCode => {
             if (browserLocale.includes(localeCode)) {
               redirectToLocale = localeCode
               return true

--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -240,9 +240,9 @@ export default async (context) => {
         // Exclude 1 for backwards compatibility and fallback when fallbackLocale is empty
       } else if (process.client && typeof navigator !== 'undefined' && navigator.language) {
         // Get browser language either from navigator if running on client side, or from the headers
-        browserLocale = navigator.language.toLocaleLowerCase().substring(0, 2)
+        browserLocale = navigator.language.toLocaleLowerCase()
       } else if (req && typeof req.headers['accept-language'] !== 'undefined') {
-        browserLocale = req.headers['accept-language'].split(',')[0].toLocaleLowerCase().substring(0, 2)
+        browserLocale = req.headers['accept-language'].split(',')[0].toLocaleLowerCase()
       }
 
       if (browserLocale) {
@@ -250,9 +250,10 @@ export default async (context) => {
         if (!useCookie || alwaysRedirect || !getLocaleCookie()) {
           let redirectToLocale = fallbackLocale
 
-          // Use browserLocale if we support it, otherwise use fallbackLocale
-          if (localeCodes.includes(browserLocale)) {
-            redirectToLocale = browserLocale
+          // Use localeCodes if browserLocale supports it, otherwise use fallbackLocale
+          // localeCodes can be the suffix of locale identifier i.e. country/region code e.g. cn or tw in case of zh-*
+          if (browserLocale.includes(localeCodes)) {
+            redirectToLocale = localeCodes
           }
 
           if (redirectToLocale && localeCodes.includes(redirectToLocale)) {


### PR DESCRIPTION
For enabling use of country/region codes instead of language codes in locales[].code so that ambiguous locales can be distinguished e.g. zh-cn vs. zh-tw