### PR TITLE
Hotfix: compare locales with suffix as case-insensitive

### DIFF
--- a/src/templates/utils-common.js
+++ b/src/templates/utils-common.js
@@ -24,7 +24,7 @@ export const matchBrowserLocale = (appLocales, browserLocales) => {
 
   // First pass: match exact locale.
   for (const [index, browserCode] of browserLocales.entries()) {
-    if (appLocales.includes(browserCode)) {
+    if (appLocales.toLowerCase().includes(browserCode.toLowerCase())) {
       matchedLocales.push({ code: browserCode, score: 1 - index / browserLocales.length })
       break
     }


### PR DESCRIPTION
Comparison of locale codes in complete fashion i.e. ISO-631 Language Code and ISO-3166 Country / Region Code concatenated with a hyphen in between needs to be done as case-insensitive.

Not only have many web developers but also we ourselves been figured out that they used to use "complete" language codes in entirely lower case letters like zh-cn, zh-tw etc.