### PR TITLE
fix: allow detecting locale from path, when it fails from name

### DIFF
--- a/src/templates/utils.js
+++ b/src/templates/utils.js
@@ -163,7 +163,8 @@ export const getLocaleFromRoute = (route = {}) => {
     if (matches && matches.length > 1) {
       return matches[1]
     }
-  } else if (route.path) {
+  }
+  if (route.path) {
     // Extract from path
     const regexp = new RegExp(`^/${localesPattern}/`, 'i')
     const matches = route.path.match(regexp)


### PR DESCRIPTION
I suggest removing `else` from getLocaleFromRoute to allow detecting locale from path, when it is not possible to be detected from name.

I will be useful when we want to have some pages, dedicated to a locale, like what is already available in basic test fixture (page under `pages/fr/`). In this case, the locale will be detected from url, and in case that the page uses some components, they will use the appropriate locale.