### PR TITLE
WIP: feature:  support for pages for an specific locale

### DIFF
--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -88,7 +88,7 @@ exports.makeRoutes = (baseRoutes, {
           localizedRoute.children = localizedRoute.children.concat(buildLocalizedRoutes(route.children[i], { locales: [locale] }, true, isExtraRouteTree))
         }
         // Remove duplicates normal routes overriding specific ones
-        route.children = removeDuplicatesOfSpecificRoutes(route.children)
+        localizedRoute.children = removeDuplicatesOfSpecificRoutes(localizedRoute.children)
       }
 
       // Get custom path if any

--- a/test/fixture/basic/pages/override.fr.vue
+++ b/test/fixture/basic/pages/override.fr.vue
@@ -1,0 +1,3 @@
+<template>
+  <h1>French</h1>
+</template>

--- a/test/fixture/basic/pages/override.vue
+++ b/test/fixture/basic/pages/override.vue
@@ -1,0 +1,3 @@
+<template>
+  <h1>English</h1>
+</template>

--- a/test/fixture/basic/pages/parent.vue
+++ b/test/fixture/basic/pages/parent.vue
@@ -1,0 +1,3 @@
+<template>
+  <nuxt-child />
+</template>

--- a/test/fixture/basic/pages/parent/override.fr.vue
+++ b/test/fixture/basic/pages/parent/override.fr.vue
@@ -1,0 +1,3 @@
+<template>
+  <h1>French</h1>
+</template>

--- a/test/fixture/basic/pages/parent/override.vue
+++ b/test/fixture/basic/pages/parent/override.vue
@@ -1,0 +1,3 @@
+<template>
+  <h1>English</h1>
+</template>


### PR DESCRIPTION
I propose a new feature, to enable users to have fully customized pages for specific locales. This can be very useful for content pages, that using translation tools will not be beneficial for them, say FAQ or about-us.

Note that using some tricks, like creating a directory for the locale (like what is done in basic fixture) will not always work, especially in scenarios including nested pages.

Using this feature, localized page 'sth.vue' can be overridden for a specific locale 'xx', using the file 'sth.xx.vue' near the original file.