### PR TITLE
chore(deps): switch to @intlify/vue-i18n-extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,12 +80,12 @@
   "dependencies": {
     "@babel/parser": "^7.5.5",
     "@babel/traverse": "^7.5.5",
+    "@intlify/vue-i18n-extensions": "^1.0.1",
     "@intlify/vue-i18n-loader": "^1.0.0",
     "cookie": "^0.4.0",
     "is-https": "^1.0.0",
     "js-cookie": "^2.2.1",
-    "vue-i18n": "^8.17.3",
-    "vue-i18n-extensions": "^0.2.1"
+    "vue-i18n": "^8.17.3"
   },
   "devDependencies": {
     "@babel/core": "7.9.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const { resolve, join } = require('path')
 const { readdirSync } = require('fs')
-const i18nExtensions = require('vue-i18n-extensions')
+const { directive: i18nExtensionsDirective } = require('@intlify/vue-i18n-extensions')
 
 const {
   MODULE_NAME,
@@ -137,5 +137,5 @@ module.exports = function (userOptions) {
 
   this.options.router.middleware.push('nuxti18n')
   this.options.render.bundleRenderer.directives = this.options.render.bundleRenderer.directives || {}
-  this.options.render.bundleRenderer.directives.t = i18nExtensions.directive
+  this.options.render.bundleRenderer.directives.t = i18nExtensionsDirective
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -966,6 +966,11 @@
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.4.tgz#cc764f92161cfb2199edf67ec1df181481014ac3"
   integrity sha512-BMwO3PruqnobOmaGBM/st2qfOekbAvoZqeGVjGOcLW4cEQAFlz7FRDoWS+xWV4yHoi32ecpWp+mciTg/9pEalA==
 
+"@intlify/vue-i18n-extensions@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@intlify/vue-i18n-extensions/-/vue-i18n-extensions-1.0.1.tgz#7b22a3664c830c8e8eabe5a8b2130aeb071c0e8f"
+  integrity sha512-vQRvxZ0GUtL5nezXr6wEjASm/cn6dhnFGq6jF33WDug4q8nm5kzn4imglmRjXVfMrCGmfXqbO12afPGgssStxA==
+
 "@intlify/vue-i18n-loader@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@intlify/vue-i18n-loader/-/vue-i18n-loader-1.0.0.tgz#4350a9b03fd62e7d7f44c7496d5509bff3229c79"
@@ -13539,11 +13544,6 @@ vue-hot-reload-api@^2.3.0:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz#532955cc1eb208a3d990b3a9f9a70574657e08f2"
   integrity sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==
-
-vue-i18n-extensions@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/vue-i18n-extensions/-/vue-i18n-extensions-0.2.1.tgz#86ebea45a1f9c9594cd124f264e107aea193d7dd"
-  integrity sha512-xBrItI7bEwBnG7eAlnyUARP41JYYn2+ABMR8q1Yh5FM9hHCbs4XPZwG+4+FPeIZ6b5gYk4YUP//m+fWiuU9z9A==
 
 vue-i18n@^8.17.3:
   version "8.17.3"


### PR DESCRIPTION
The old vue-i18n-extensions was moved to organization and old package
won't receive updates.