### PR TITLE
chore(docs): add example for wildcard route configuration

### DIFF
--- a/docs/es/routing.md
+++ b/docs/es/routing.md
@@ -151,9 +151,10 @@ pages/
 ├── _nested/
 ├──── _route/
 ├────── index.vue
+├────── _.vue
 ```
 
-Así es como configuraría esta página en particular en la configuración:
+Así es como configuraría estas páginas en particular en la configuración:
 
 ```js
 // nuxt.config.js
@@ -163,6 +164,9 @@ Así es como configuraría esta página en particular en la configuración:
   pages: {
     '_nested/_route/index': {
       en: '/mycustompath/:nested/:route?' // Params need to be put back here as you would with vue-router
+    },
+    '_nested/_route/_': {
+      en: '/mycustompath/:nested/*' // * will match the entire route path after /:nested/
     }
   }
 }]

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -163,16 +163,17 @@ Localized routes are full URIs, so keep in mind that:
 
 #### Example 1
 
-Say you have some nested page like:
+Say you have some nested pages like:
 
 ```asciidoc
 pages/
 ├── _nested/
 ├──── _route/
 ├────── index.vue
+├────── _.vue
 ```
 
-Here's how you would configure this particular page in the configuration:
+Here's how you would configure these particular pages in the configuration:
 
 ```js
 // nuxt.config.js
@@ -182,6 +183,9 @@ Here's how you would configure this particular page in the configuration:
   pages: {
     '_nested/_route/index': {
       en: '/mycustompath/:nested/:route?' // Params need to be put back here as you would with vue-router
+    },
+    '_nested/_route/_': {
+      en: '/mycustompath/:nested/*' // * will match the entire route path after /:nested/
     }
   }
 }]


### PR DESCRIPTION
As I spent some times to understand how to customize i18n urls for wildcard pages (`_.vue`), I suggest an example in the documentation to illustrate it.