### PR TITLE
fix: redirect from 404 to defaultLocale if there is matching route

### DIFF
--- a/docs/es/options-reference.md
+++ b/docs/es/options-reference.md
@@ -23,8 +23,10 @@ Aquí están todas las opciones disponibles al configurar el módulo y sus valor
   //   - code of ISO 639-1 and code of ISO 3166-1 alpha-2, with a hyphen (e.g. 'en-US')
   locales: [],
 
-  // The app's default locale, URLs for this locale won't have a prefix if
-  // strategy is prefix_except_default
+  // The app's default locale.
+  // When using 'prefix_except_default' strategy, URLs for this locale won't have a prefix.
+  // It's recommended to set this to some locale regardless of chosen strategy, as it will be
+  // used as a locale fallback to use when navigating to a non-existent route.
   defaultLocale: null,
 
   // Separator used to generated routes name for each locale, you shouldn't

--- a/docs/es/routing.md
+++ b/docs/es/routing.md
@@ -63,8 +63,8 @@ Con esta estrategia, todas las rutas tendrán un prefijo de configuración local
 
 Esta estrategia combina los comportamientos de ambas estrategias anteriores, lo que significa que obtendrá URL con prefijos para cada idioma, pero las URL para el idioma predeterminado también tendrán una versión sin prefijo.
 
-Para configurar la estrategia, use la opción `strategy`. Asegúrese de tener un `defaultLocale` definido si usa **prefix_except_default**, **prefix_and_default** o la estrategia **no_prefix**.
-
+Para configurar la estrategia, use la opción `strategy`.
+Make sure that you have a `defaultLocale` defined, especially if using **prefix_except_default**, **prefix_and_default** or **no_prefix** strategy. For other strategies it's also recommended to set it as it's gonna be used as a fallback when attempting to redirect from 404 page.
 
 ```js
 // nuxt.config.js

--- a/docs/options-reference.md
+++ b/docs/options-reference.md
@@ -36,8 +36,10 @@ Here are all the options available when configuring the module and their default
   //   - code of ISO 639-1 and code of ISO 3166-1 alpha-2, with a hyphen (e.g. 'en-US')
   locales: [],
 
-  // The app's default locale, URLs for this locale won't have a prefix if
-  // strategy is prefix_except_default
+  // The app's default locale.
+  // When using 'prefix_except_default' strategy, URLs for this locale won't have a prefix.
+  // It's recommended to set this to some locale regardless of chosen strategy, as it will be
+  // used as a locale fallback to use when navigating to a non-existent route.
   defaultLocale: null,
 
   // Separator used to generated routes name for each locale, you shouldn't

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -66,8 +66,8 @@ This strategy combines both previous strategies behaviours, meaning that you wil
 
 ### Configuration
 
-To configure the strategy, use the `strategy` option. Make sure that you have a `defaultLocale` defined if using **prefix_except_default**, **prefix_and_default** or **no_prefix** strategy.
-
+To configure the strategy, use the `strategy` option.
+Make sure that you have a `defaultLocale` defined, especially if using **prefix_except_default**, **prefix_and_default** or **no_prefix** strategy. For other strategies it's also recommended to set it as it's gonna be used as a fallback when attempting to redirect from 404 page.
 
 ```js
 // nuxt.config.js

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "scripts": {
     "dev:basic": "nuxt -c ./test/fixture/basic/nuxt.config.js",
+    "dev:basic:generate": "nuxt generate -c ./test/fixture/basic/nuxt.config.js",
     "coverage": "codecov",
     "lint": "eslint --ext .js,.vue,.ts src test types",
     "test": "yarn test:types && yarn test:unit && yarn test:e2e-ssr && yarn test:e2e-browser",

--- a/src/templates/middleware.js
+++ b/src/templates/middleware.js
@@ -1,37 +1,11 @@
 import middleware from '../middleware'
-import { baseUrl, detectBrowserLanguage, rootRedirect } from './options'
-import { getLocaleFromRoute } from './utils'
-import { resolveBaseUrl } from './utils-common'
 
 middleware.nuxti18n = async (context) => {
-  const { app, route, redirect, isHMR } = context
+  const { app, isHMR } = context
 
   if (isHMR) {
     return
   }
 
-  // Handle root path redirect
-  if (route.path === '/' && rootRedirect) {
-    let statusCode = 302
-    let path = rootRedirect
-
-    if (typeof rootRedirect !== 'string') {
-      statusCode = rootRedirect.statusCode
-      path = rootRedirect.path
-    }
-
-    redirect(statusCode, '/' + path, route.query)
-    return
-  }
-
-  app.i18n.__baseUrl = resolveBaseUrl(baseUrl, context)
-
-  if (detectBrowserLanguage && await app.i18n.__detectBrowserLanguage()) {
-    return
-  }
-
-  const locale = app.i18n.locale || app.i18n.defaultLocale || ''
-  const routeLocale = getLocaleFromRoute(route)
-
-  await app.i18n.setLocale(routeLocale || locale)
+  await app.i18n.__onNavigate()
 }

--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -131,7 +131,7 @@ function switchLocalePath (locale) {
 }
 
 function getRouteBaseName (givenRoute) {
-  const route = givenRoute || this.route
+  const route = givenRoute !== undefined ? givenRoute : this.route
   if (!route.name) {
     return null
   }

--- a/src/templates/utils.js
+++ b/src/templates/utils.js
@@ -70,65 +70,6 @@ export const validateRouteParams = routeParams => {
   })
 }
 
-const trailingSlashRE = /\/?$/
-
-/**
- * Determines if objects are equal.
- *
- * @param {Object} [a={}]
- * @param {Object} [b={}]
- * @return {boolean} True if objects equal, False otherwise.
- */
-function isObjectEqual (a = {}, b = {}) {
-  // handle null value #1566
-  if (!a || !b) {
-    return a === b
-  }
-  const aKeys = Object.keys(a)
-  const bKeys = Object.keys(b)
-  if (aKeys.length !== bKeys.length) {
-    return false
-  }
-  return aKeys.every(key => {
-    const aVal = a[key]
-    const bVal = b[key]
-    // check nested equality
-    if (typeof aVal === 'object' && typeof bVal === 'object') {
-      return isObjectEqual(aVal, bVal)
-    }
-    return String(aVal) === String(bVal)
-  })
-}
-
-/**
- * Determines if two routes are the same.
- *
- * @param {Route} a
- * @param {Route} [b]
- * @return {boolean} True if routes the same, False otherwise.
- */
-export function isSameRoute (a, b) {
-  if (!b) {
-    return false
-  }
-  if (a.path && b.path) {
-    return (
-      a.path.replace(trailingSlashRE, '') === b.path.replace(trailingSlashRE, '') &&
-      a.hash === b.hash &&
-      isObjectEqual(a.query, b.query)
-    )
-  }
-  if (a.name && b.name) {
-    return (
-      a.name === b.name &&
-      a.hash === b.hash &&
-      isObjectEqual(a.query, b.query) &&
-      isObjectEqual(a.params, b.params)
-    )
-  }
-  return false
-}
-
 /**
  * Get locale code that corresponds to current hostname
  * @param  {VueI18n} nuxtI18n Instance of VueI18n

--- a/src/templates/utils.js
+++ b/src/templates/utils.js
@@ -1,12 +1,7 @@
 import {
-  defaultLocaleRouteNameSuffix,
-  localeCodes,
   LOCALE_CODE_KEY,
-  LOCALE_DOMAIN_KEY,
   LOCALE_FILE_KEY,
-  MODULE_NAME,
-  routesNameSeparator,
-  vuex
+  MODULE_NAME
 } from './options'
 
 /**
@@ -43,92 +38,6 @@ export async function loadLanguageAsync (context, locale) {
         // eslint-disable-next-line no-console
         console.warn(`[${MODULE_NAME}] Could not find lang file for locale ${locale}`)
       }
-    }
-  }
-}
-
-const isObject = value => value && !Array.isArray(value) && typeof value === 'object'
-
-/**
- * Validate setRouteParams action's payload
- * @param {*} routeParams The action's payload
- */
-export const validateRouteParams = routeParams => {
-  if (!isObject(routeParams)) {
-    // eslint-disable-next-line no-console
-    console.warn(`[${MODULE_NAME}] Route params should be an object`)
-    return
-  }
-  Object.entries(routeParams).forEach(([key, value]) => {
-    if (!localeCodes.includes(key)) {
-    // eslint-disable-next-line no-console
-      console.warn(`[${MODULE_NAME}] Trying to set route params for key ${key} which is not a valid locale`)
-    } else if (!isObject(value)) {
-    // eslint-disable-next-line no-console
-      console.warn(`[${MODULE_NAME}] Trying to set route params for locale ${key} with a non-object value`)
-    }
-  })
-}
-
-/**
- * Get locale code that corresponds to current hostname
- * @param  {VueI18n} nuxtI18n Instance of VueI18n
- * @param  {object} req Request object
- * @return {String} Locade code found if any
- */
-export const getLocaleDomain = (nuxtI18n, req) => {
-  const hostname = process.client ? window.location.hostname : (req.headers['x-forwarded-host'] || req.headers.host)
-  if (hostname) {
-    const localeDomain = nuxtI18n.locales.find(l => l[LOCALE_DOMAIN_KEY] === hostname)
-    if (localeDomain) {
-      return localeDomain[LOCALE_CODE_KEY]
-    }
-  }
-  return null
-}
-
-/**
- * Extract locale code from given route:
- * - If route has a name, try to extract locale from it
- * - Otherwise, fall back to using the routes'path
- * @param  {Object} route               Route
- * @return {String}                     Locale code found if any
- */
-export const getLocaleFromRoute = (route = {}) => {
-  const localesPattern = `(${localeCodes.join('|')})`
-  const defaultSuffixPattern = `(?:${routesNameSeparator}${defaultLocaleRouteNameSuffix})?`
-  // Extract from route name
-  if (route.name) {
-    const regexp = new RegExp(`${routesNameSeparator}${localesPattern}${defaultSuffixPattern}$`, 'i')
-    const matches = route.name.match(regexp)
-    if (matches && matches.length > 1) {
-      return matches[1]
-    }
-  } else if (route.path) {
-    // Extract from path
-    const regexp = new RegExp(`^/${localesPattern}/`, 'i')
-    const matches = route.path.match(regexp)
-    if (matches && matches.length > 1) {
-      return matches[1]
-    }
-  }
-  return null
-}
-
-/**
- * Dispatch store module actions to keep it in sync with app's locale data
- * @param  {Store} store     Vuex store
- * @param  {String} locale   Current locale
- * @param  {Object} messages Current messages
- * @return {Promise(void)}
- */
-export const syncVuex = async (store, locale = null, messages = null) => {
-  if (vuex && store) {
-    if (locale !== null && vuex.syncLocale) {
-      await store.dispatch(vuex.moduleName + '/setLocale', locale)
-    }
-    if (messages !== null && vuex.syncMessages) {
-      await store.dispatch(vuex.moduleName + '/setMessages', messages)
     }
   }
 }

--- a/test/fixture/basic/components/LangSwitcher.vue
+++ b/test/fixture/basic/components/LangSwitcher.vue
@@ -1,10 +1,22 @@
 <template>
-  <div id="lang-switcher">
-    <nuxt-link
-      v-for="(locale, index) in localesExcludingCurrent"
-      :key="index"
-      :exact="true"
-      :to="switchLocalePath(locale.code)">{{ locale.name }}</nuxt-link>
+  <div>
+    <strong>Using nuxt-link</strong>:
+    <div id="lang-switcher">
+      <nuxt-link
+        v-for="(locale, index) in localesExcludingCurrent"
+        :key="index"
+        :exact="true"
+        :to="switchLocalePath(locale.code)">{{ locale.name }}</nuxt-link>
+    </div>
+    <strong>Using setLocale()</strong>:
+    <div>
+      <a
+        v-for="(locale, index) in localesExcludingCurrent"
+        :id="`set-locale-link-${locale.code}`"
+        :key="`b-${index}`"
+        href="#"
+        @click.prevent="$i18n.setLocale(locale.code)">{{ locale.name }}</a>
+    </div>
   </div>
 </template>
 

--- a/test/fixture/basic/pages/posts/_slug.vue
+++ b/test/fixture/basic/pages/posts/_slug.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <h2>{{ $route.params.slug }}</h2>
-    <nuxt-link exact :to="localePath('posts')">index</nuxt-link>
+    <nuxt-link id="post-link" exact :to="localePath('posts')">index</nuxt-link>
   </div>
 </template>
 

--- a/test/fixture/basic/pages/posts/index.vue
+++ b/test/fixture/basic/pages/posts/index.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <nuxt-link
+      id="post-link"
       exact
       :to="localePath({
         name: 'posts-slug',


### PR DESCRIPTION
fix: redirect from 404 to defaultLocale if there is matching route

Changes the `setLocale` logic to, in case current route is 404, to
try to find a matching one for current locale. This is for situations
when using `prefix` strategy where the root (`/`) route doesn't exist.
We will try to find and redirect to prefixed route matching resolved locale.

Also worked around Nuxt issue (https://github.com/nuxt/nuxt.js/issues/4491 )
with `redirect` not working when called from a plugin in SPA mode.
Required for the above fix above to be functional in SPA.

Resolves #677
Resolves #491