### PR TITLE
feat: add DocSearch as recommended by vuepress

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -13,6 +13,10 @@ module.exports = {
     }
   },
   themeConfig: {
+    algolia: {
+      apiKey: '3e37c242d902c4d6c469abc8573b7533',
+      indexName: 'nuxt-i18n'
+    },
     repo: 'nuxt-community/nuxt-i18n',
     editLinks: true,
     docsDir: 'docs',


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Vuepress](https://vuepress.vuejs.org/theme/default-theme-config.html#algolia-search). We thought it is a shame you can not also used this search that you can [find on vuejs for example](https://vuejs.org/).

This PR will add DocSearch to the documentation website. It will allow a user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.