### PR TITLE
fix: ignore browser-detection by nuxt generate

### DIFF
--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -127,7 +127,7 @@ export default async (context) => {
 
   const doDetectBrowserLanguage = () => {
     // Browser detection is ignored if it is a nuxt generate.
-    if (context.isStatic && context.ssrContext) {
+    if (process.static && process.server) {
       return false
     }
 

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -126,6 +126,11 @@ export default async (context) => {
   }
 
   const doDetectBrowserLanguage = () => {
+    // Browser detection is ignored if it is a nuxt generate.
+    if (context.isStatic && context.ssrContext) {
+      return false
+    }
+
     const { alwaysRedirect, fallbackLocale } = detectBrowserLanguage
 
     let matchedLocale


### PR DESCRIPTION
This commit tries to fix issue [#689](https://github.com/nuxt-community/nuxt-i18n/issues/689).

With `nuxt generate` the browser detection is ignored.
Language of the route will not be changed and routes can be rendered.