### PR TITLE
fix: trigger language detection on initial load in generated mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,7 @@ module.exports = function (userOptions) {
 
   const templatesOptions = {
     ...options,
+    IS_UNIVERSAL_MODE: this.options.mode === 'universal',
     MODULE_NAME,
     LOCALE_CODE_KEY,
     LOCALE_ISO_KEY,

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -8,6 +8,7 @@ import {
   defaultLocaleRouteNameSuffix,
   detectBrowserLanguage,
   differentDomains,
+  IS_UNIVERSAL_MODE,
   lazy,
   LOCALE_CODE_KEY,
   LOCALE_DOMAIN_KEY,
@@ -241,4 +242,9 @@ export default async (context) => {
   const detectedBrowserLocale = detectBrowserLanguage && doDetectBrowserLanguage()
   finalLocale = detectedBrowserLocale || finalLocale
   await loadAndSetLocale(finalLocale, { initialSetup: true })
+
+  // Trigger onNavigate manually for Nuxt generate in universal mode as Nuxt doesn't do that on load.
+  if (process.client && process.static && IS_UNIVERSAL_MODE) {
+    await onNavigate()
+  }
 }

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -204,11 +204,9 @@ describe(`${browserString} (generate with detectBrowserLanguage.fallbackLocale)`
   })
 
   test('redirects to browser locale', async () => {
-    page = await browser.newPage()
+    page = await browser.newPage({ locale: 'fr' })
     await page.goto(server.getUrl('/'))
-    expect(await (await page.$('body')).textContent()).toContain('locale: en')
-
-    await navigate(page, '/fr')
+    expect(page.url()).toBe(server.getUrl('/fr'))
     expect(await (await page.$('body')).textContent()).toContain('locale: fr')
   })
 })


### PR DESCRIPTION
With Nuxt generate & universal mode Nuxt doesn't trigger middleware
on initial loading so we need to do it manually so that possible
redirection is handled.