### PR TITLE
fix: don't leave out non-prefixed routes for generate + prefix strategy

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,11 @@ module.exports = {
   ],
   rules: {
     'arrow-parens': 'off',
+    'no-console': [
+        'error', {
+            allow: ['assert', 'warn', 'error', 'info'],
+        },
+    ],
     'vue/html-closing-bracket-newline': 'off',
     'vue/multiline-html-element-content-newline': 'off',
     'vue/singleline-html-element-content-newline': 'off'

--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -7,6 +7,7 @@ exports.makeRoutes = (baseRoutes, {
   defaultLocale,
   routesNameSeparator,
   defaultLocaleRouteNameSuffix,
+  isNuxtGenerate,
   strategy,
   parsePages,
   pages,
@@ -118,6 +119,13 @@ exports.makeRoutes = (baseRoutes, {
 
       if (shouldAddPrefix) {
         path = `/${locale}${path}`
+
+        if (locale === defaultLocale && strategy === STRATEGIES.PREFIX && isNuxtGenerate) {
+          routes.push({
+            path: route.path,
+            redirect: path
+          })
+        }
       }
 
       localizedRoute.path = path

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,8 @@ module.exports = function (userOptions) {
 
   if (options.strategy !== STRATEGIES.NO_PREFIX) {
     if (localeCodes.length) {
-      this.extendRoutes((routes) => {
+      let isNuxtGenerate = false
+      const extendRoutes = routes => {
         // This import (or more specifically 'vue-template-compiler' in helpers/components.js) needs to
         // be required only at build time to avoid problems when 'vue-template-compiler' dependency is
         // not available (at runtime, when using nuxt-start).
@@ -63,11 +64,17 @@ module.exports = function (userOptions) {
 
         const localizedRoutes = makeRoutes(routes, {
           ...options,
-          pagesDir
+          pagesDir,
+          isNuxtGenerate
         })
         routes.splice(0, routes.length)
         routes.unshift(...localizedRoutes)
-      })
+      }
+
+      // Doesn't seem like we can tell whether we are in nuxt generate from the module so we'll
+      // take advantage of the 'generate:before' hook to store variable.
+      this.nuxt.hook('generate:before', () => { isNuxtGenerate = true })
+      this.nuxt.hook('build:extendRoutes', routes => extendRoutes(routes, isNuxtGenerate))
     }
   } else if (options.differentDomains) {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
To avoid having to create server-side redirect rules, the non-prefixed
routes are not removed when using prefix strategy with Nuxt generate.
The non-prefixed routes should automatically redirect to default locale
routes.

Resolves #700