### PR TITLE
fix: remove "encodePaths" option and don't encode paths by default

### DIFF
--- a/docs/es/routing.md
+++ b/docs/es/routing.md
@@ -229,19 +229,6 @@ Debería configurar su propiedad `pages` de la siguiente manera:
 
 Si falta una ruta personalizada para una de las configuraciones locales, se usa la ruta personalizada `defaultLocale` si está establecida..
 
-### Expresión regular
-
-Por defecto, todas las rutas personalizadas están codificadas para manejar caracteres no latinos en la ruta. Esto convertirá rutas con expresiones regulares como `/foo/:slug-:id(\\d+)` a `/foo/:slug-:id(%5Cd+)`.
-
-Si desea utilizar expresiones regulares en sus rutas personalizadas, debe establecer la opción  `encodePaths` en false. Como no ocurrirá ninguna codificación, deberá asegurarse de pasar las rutas codificadas usted mismo.
-```js
-// nuxt.config.js
-
-['nuxt-i18n', {
-  encodePaths: false
-}]
-```
-
 
 ## Ignorar rutas
 

--- a/docs/options-reference.md
+++ b/docs/options-reference.md
@@ -135,12 +135,6 @@ Here are all the options available when configuring the module and their default
   // the pages option, refer to the "Routing" section for usage
   pages: {},
 
-  // By default, custom paths will be encoded using encodeURI method.
-  // This does not work with regexp: "/foo/:slug-:id(\\d+)". If you want to use
-  // regexp in the path, then set this option to false, and make sure you process
-  // path encoding yourself.
-  encodePaths: true,
-
   // Called right before app's locale changes
   beforeLanguageSwitch: (oldLocale, newLocale) => null,
 

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -248,20 +248,6 @@ You would need to set up your `pages` property as follows:
 
 If a custom path is missing for one of the locales, the `defaultLocale` custom path is used, if set.
 
-### Regular Expression
-
-By default, all custom paths are encoded to handle non-latin characters in the path. This will convert paths with regular expression like `/foo/:slug-:id(\\d+)` to `/foo/:slug-:id(%5Cd+)`.
-
-If you would like to use regular expression in your custom paths, then you need to set the `encodePaths` option to false. Since no encoding will happen, you will have to make sure to pass in encoded paths yourself.
-
-```js
-// nuxt.config.js
-
-['nuxt-i18n', {
-  encodePaths: false
-}]
-```
-
 
 ## Ignore routes
 

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -48,7 +48,6 @@ exports.DEFAULT_OPTIONS = {
   },
   parsePages: true,
   pages: {},
-  encodePaths: true,
   beforeLanguageSwitch: () => null,
   onLanguageSwitched: () => null
 }

--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -11,7 +11,6 @@ exports.makeRoutes = (baseRoutes, {
   strategy,
   parsePages,
   pages,
-  encodePaths,
   pagesDir,
   differentDomains
 }) => {
@@ -76,7 +75,7 @@ exports.makeRoutes = (baseRoutes, {
 
       // Get custom path if any
       if (componentOptions.paths && componentOptions.paths[locale]) {
-        path = encodePaths ? encodeURI(componentOptions.paths[locale]) : componentOptions.paths[locale]
+        path = componentOptions.paths[locale]
       }
 
       // For PREFIX_AND_DEFAULT strategy and default locale:

--- a/types/nuxt-i18n.d.ts
+++ b/types/nuxt-i18n.d.ts
@@ -60,7 +60,6 @@ declare namespace NuxtVueI18n {
     interface AllOptionsInterface extends NuxtI18nInterface {
       baseUrl?: string | ((context: NuxtContext) => string)
       detectBrowserLanguage?: DetectBrowserLanguageInterface
-      encodePaths?: boolean
       langDir?: string | null
       lazy?: boolean
       // see https://goo.gl/NbzX3f


### PR DESCRIPTION
This could be considered a breaking change but since I only know of it
breaking things rather than helping anything and there are no tests that
would prove me otherwise, I think it's safe to remove without releasing
a major version.

Also, Nuxt doesn't encode paths either so this change aligns with it.

Resolves #712