### PR TITLE
fix: favor non-prefixed route with prefix_and_default strategy

### DIFF
--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -55,15 +55,15 @@ function localeRoute (route, locale) {
   const localizedRoute = Object.assign({}, route)
 
   if (route.path && !route.name) {
+    const isDefaultLocale = locale === defaultLocale
     // if route has a path defined but no name, resolve full route using the path
-    const isPrefixed = (
-      // don't prefix default locale
-      !(locale === defaultLocale && strategy === STRATEGIES.PREFIX_EXCEPT_DEFAULT) &&
+    const isPrefixed =
+        // don't prefix default locale
+        !(isDefaultLocale && [STRATEGIES.PREFIX_EXCEPT_DEFAULT, STRATEGIES.PREFIX_AND_DEFAULT].includes(strategy)) &&
         // no prefix for any language
         !(strategy === STRATEGIES.NO_PREFIX) &&
         // no prefix for different domains
         !i18n.differentDomains
-    )
 
     const path = (isPrefixed ? `/${locale}${route.path}` : route.path)
 

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -617,10 +617,17 @@ describe('prefix_and_default strategy', () => {
     await expect(get('/fr')).resolves.toContain('page: Accueil')
   })
 
-  test('localeRoute returns localized route name for default locale', async () => {
+  test('localeRoute returns localized route (by route name)', async () => {
     const window = await nuxt.renderAndGetWindow(url('/'))
     expect(window.$nuxt.localeRoute('index', 'en')).toMatchObject({ name: 'index___en___default', fullPath: '/' })
     expect(window.$nuxt.localeRoute('index', 'fr')).toMatchObject({ name: 'index___fr', fullPath: '/fr' })
+  })
+
+  test('localeRoute returns localized route (by route path)', async () => {
+    const window = await nuxt.renderAndGetWindow(url('/'))
+    // Prefer unprefixed path for default locale:
+    expect(window.$nuxt.localeRoute('/simple', 'en')).toMatchObject({ name: 'simple___en___default', fullPath: '/simple' })
+    expect(window.$nuxt.localeRoute('/simple', 'fr')).toMatchObject({ name: 'simple___fr', fullPath: '/fr/simple' })
   })
 
   test('canonical SEO link is added to prefixed default locale', async () => {


### PR DESCRIPTION
When using "localePath" with a route path argument (rather than route name),
there was a bug with picking prefixed route path for default
route rather than preferred non-prefixed path.

Resolve #721