### PR TITLE
fix: don't add trailing slashes to generated routes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,7 @@ module.exports = function (userOptions) {
 
   if (options.strategy !== STRATEGIES.NO_PREFIX) {
     if (localeCodes.length) {
+      const { trailingSlash } = this.options.router
       let isNuxtGenerate = false
       const extendRoutes = routes => {
         // This import (or more specifically 'vue-template-compiler' in helpers/components.js) needs to
@@ -65,7 +66,8 @@ module.exports = function (userOptions) {
         const localizedRoutes = makeRoutes(routes, {
           ...options,
           pagesDir,
-          isNuxtGenerate
+          isNuxtGenerate,
+          trailingSlash
         })
         routes.splice(0, routes.length)
         routes.unshift(...localizedRoutes)

--- a/src/templates/seo-head.js
+++ b/src/templates/seo-head.js
@@ -66,11 +66,11 @@ function addHreflangLinks (locales, baseUrl, link) {
     localeMap.set(localeIso, locale)
   }
 
-  for (const [iso, locale] of localeMap.entries()) {
+  for (const [iso, mapLocale] of localeMap.entries()) {
     link.push({
       hid: `alternate-hreflang-${iso}`,
       rel: 'alternate',
-      href: baseUrl + this.switchLocalePath(locale.code),
+      href: baseUrl + this.switchLocalePath(mapLocale.code),
       hreflang: iso
     })
   }


### PR DESCRIPTION
Module was adding a trailing slash for extra routes that
it was generating.

This isn't normally a problem as VueRouter runs by default in
non-strict mode and normalizes paths to not have trailing slashes but
when the "router.trailingSlash = false" option was set in Nuxt, then
the matching was strict and actually made trailing slashes appear in
the path.

Follow the same logic as Nuxt and:
 - don't add trailing slashes by default or when "router.trailingSlash"
   option is set to "false"
 - add trailing slashes when "router.trailingSlash" option is set
   to "true"

Resolves #717