### PR TITLE
feat: pass to-be-loaded locale when lazy-loading from exported function

### DIFF
--- a/docs/es/lazy-load-translations.md
+++ b/docs/es/lazy-load-translations.md
@@ -51,14 +51,14 @@ Ejemplo de archivo de idioma:
 ```js
 // lang/[lang].js
 
-export default (context) => {
-  return new Promise(function (resolve) {
-    resolve({
-      welcome: 'Welcome'
-    })
-  });
+export default async (context, locale) => {
+  await resolve({
+    welcome: 'Welcome'
+  })
 }
+
 // or
+
 export default {
   welcome: 'Welcome'
 }

--- a/docs/lazy-load-translations.md
+++ b/docs/lazy-load-translations.md
@@ -51,14 +51,14 @@ Language file example:
 ```js
 // lang/[lang].js
 
-export default (context) => {
-  return new Promise(function (resolve) {
-    resolve({
-      welcome: 'Welcome'
-    })
-  });
+export default async (context, locale) => {
+  await resolve({
+    welcome: 'Welcome'
+  })
 }
+
 // or
+
 export default {
   welcome: 'Welcome'
 }

--- a/src/templates/utils.js
+++ b/src/templates/utils.js
@@ -26,7 +26,7 @@ export async function loadLanguageAsync (context, locale) {
         try {
           const module = await import(/* webpackChunkName: "lang-[request]" */ '~/<%= options.langDir %>' + file)
           const messages = module.default ? module.default : module
-          const result = typeof messages === 'function' ? await Promise.resolve(messages(context)) : messages
+          const result = typeof messages === 'function' ? await Promise.resolve(messages(context, locale)) : messages
           app.i18n.setLocaleMessage(locale, result)
           app.i18n.loadedLanguages.push(locale)
         } catch (error) {

--- a/test/fixture/basic/lang/fr-FR.js
+++ b/test/fixture/basic/lang/fr-FR.js
@@ -1,0 +1,8 @@
+export default (_context, locale) => {
+  return {
+    home: 'Accueil',
+    about: 'À propos',
+    posts: 'Articles',
+    locale
+  }
+}

--- a/test/fixture/basic/pages/locale.vue
+++ b/test/fixture/basic/pages/locale.vue
@@ -1,0 +1,7 @@
+<template>
+  <div id="t">{{ $t('locale') }}</div>
+</template>
+
+<script>
+export default {}
+</script>

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -567,6 +567,20 @@ describe('lazy loading', () => {
     const title = dom.querySelector('h1')
     expect(title.textContent).toBe('in english')
   })
+
+  test('loads strings from file exporting a function', async () => {
+    const html = await get('/fr/simple')
+    const dom = getDom(html)
+    const container = dom.querySelector('#container')
+    expect(container.textContent).toBe('Accueil')
+  })
+
+  test('exported function gets passed locale to load', async () => {
+    const html = await get('/fr/locale')
+    const dom = getDom(html)
+    const container = dom.querySelector('#t')
+    expect(container.textContent).toBe('fr')
+  })
 })
 
 describe('with empty configuration', () => {


### PR DESCRIPTION
When using the function export for lazy-loaded locales, the function
will now also receive locale code, apart from context.

Resolves #742