### PR TITLE
fix: initial redirect breaks reactivity in static mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [6.13.0-beta.0](https://github.com/nuxt-community/nuxt-i18n/compare/v6.12.2...v6.13.0-beta.0) (2020-06-03)
+
+
+### Features
+
+* pass to-be-loaded locale when lazy-loading from exported function ([#752](https://github.com/nuxt-community/nuxt-i18n/issues/752)) ([145f3b2](https://github.com/nuxt-community/nuxt-i18n/commit/145f3b2a080a91028fd5ef59f9c8bd88755d3b4b)), closes [#742](https://github.com/nuxt-community/nuxt-i18n/issues/742)
+
+
+### Bug Fixes
+
+* initial redirect breaks reactivity in static mode ([ef80b0d](https://github.com/nuxt-community/nuxt-i18n/commit/ef80b0db8e2a74101929a063e7142b7ab5708ef0)), closes [#737](https://github.com/nuxt-community/nuxt-i18n/issues/737)
+
 ### [6.12.2](https://github.com/nuxt-community/nuxt-i18n/compare/v6.12.1...v6.12.2) (2020-06-02)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-i18n",
-  "version": "6.12.2",
+  "version": "6.13.0-beta.0",
   "description": "i18n for Nuxt",
   "license": "MIT",
   "contributors": [

--- a/src/templates/middleware.js
+++ b/src/templates/middleware.js
@@ -1,5 +1,6 @@
 import middleware from '../middleware'
 
+/** @type {import('@nuxt/types').Middleware} */
 middleware.nuxti18n = async (context) => {
   const { app, isHMR } = context
 
@@ -7,5 +8,8 @@ middleware.nuxti18n = async (context) => {
     return
   }
 
-  await app.i18n.__onNavigate()
+  const [status, redirectPath] = await app.i18n.__onNavigate(context.route)
+  if (status && redirectPath) {
+    context.redirect(status, redirectPath)
+  }
 }

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -163,6 +163,33 @@ describe(`${browserString} (generate)`, () => {
     await navigate(page, '/')
     expect(await (await page.$('body')).textContent()).toContain('locale: en')
   })
+
+  // Issue https://github.com/nuxt-community/nuxt-i18n/issues/737
+  test('reactivity works after redirecting to detected browser locale (root path)', async () => {
+    page = await browser.newPage({ locale: 'fr' })
+    await page.goto(server.getUrl('/'))
+    expect(page.url()).toBe(server.getUrl('/fr/'))
+    // Need to delay a bit due to vue-meta batching with 10ms timeout.
+    await page.waitForTimeout(20)
+    expect(await page.title()).toBe('Accueil')
+
+    await navigate(page, '/')
+    await page.waitForTimeout(20)
+    expect(await page.title()).toBe('Homepage')
+  })
+
+  test('reactivity works after redirecting to detected browser locale (sub-path)', async () => {
+    page = await browser.newPage({ locale: 'fr' })
+    await page.goto(server.getUrl('/posts/'))
+    expect(page.url()).toBe(server.getUrl('/fr/articles/'))
+    // Need to delay a bit due to vue-meta batching with 10ms timeout.
+    await page.waitForTimeout(20)
+    expect(await page.title()).toBe('Articles')
+
+    await navigate(page, '/posts/')
+    await page.waitForTimeout(20)
+    expect(await page.title()).toBe('Posts')
+  })
 })
 
 describe(`${browserString} (generate, prefix strategy)`, () => {
@@ -252,7 +279,7 @@ describe(`${browserString} (generate with detectBrowserLanguage.fallbackLocale)`
   test('redirects to browser locale', async () => {
     page = await browser.newPage({ locale: 'fr' })
     await page.goto(server.getUrl('/'))
-    expect(page.url()).toBe(server.getUrl('/fr'))
+    expect(page.url()).toBe(server.getUrl('/fr/'))
     expect(await (await page.$('body')).textContent()).toContain('locale: fr')
   })
 })

--- a/test/fixture/basic/pages/index.vue
+++ b/test/fixture/basic/pages/index.vue
@@ -13,6 +13,11 @@ import LangSwitcher from '../components/LangSwitcher'
 export default {
   components: {
     LangSwitcher
+  },
+  head () {
+    return {
+      title: this.$t('home')
+    }
   }
 }
 </script>

--- a/test/fixture/basic/pages/posts.vue
+++ b/test/fixture/basic/pages/posts.vue
@@ -13,6 +13,11 @@ export default {
   components: {
     LangSwitcher
   },
+  head () {
+    return {
+      title: this.$t('posts')
+    }
+  },
   nuxtI18n: {
     paths: {
       fr: '/articles'


### PR DESCRIPTION
When we've detected browser language and need to redirect we need to do
it from the middleware for the page to transition correctly. The problem
is Nuxt doesn't trigger middleware for initial navigation in static
mode (the idea is that it already ran when generating page on the server),
so we can't do it properly.

Fixed by hooking into the VueRouter "beforeEach" navigation hook so that
we can handle it from the right place. Still, as Nuxt doesn't know that
we are redirecting, it would throw some errors trying to load previous
page. So use "location.assign()" to "hard" redirect.

Resolves #737