### PR TITLE
fix: handling of trailing slash in localePath

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "dev:basic": "nuxt -c ./test/fixture/basic/nuxt.config.js",
     "dev:basic:generate": "nuxt generate -c ./test/fixture/basic/nuxt.config.js",
+    "start:dist": "node -r esm ./test/utils/http-server-internal.js --port 8080 -v dist",
     "coverage": "codecov",
     "lint": "eslint --ext .js,.vue,.ts src test types",
     "test": "yarn test:types && yarn test:unit && yarn test:e2e-ssr && yarn test:e2e-browser",

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ module.exports = function (userOptions) {
   }
 
   const localeCodes = getLocaleCodes(options.locales)
+  const { trailingSlash } = this.options.router
 
   const templatesOptions = {
     ...options,
@@ -47,15 +48,14 @@ module.exports = function (userOptions) {
     LOCALE_FILE_KEY,
     STRATEGIES,
     COMPONENT_OPTIONS_KEY,
-    localeCodes
+    localeCodes,
+    trailingSlash
   }
 
-  // Generate localized routes
   const pagesDir = this.options.dir && this.options.dir.pages ? this.options.dir.pages : 'pages'
 
   if (options.strategy !== STRATEGIES.NO_PREFIX) {
     if (localeCodes.length) {
-      const { trailingSlash } = this.options.router
       let isNuxtGenerate = false
       const extendRoutes = routes => {
         // This import (or more specifically 'vue-template-compiler' in helpers/components.js) needs to

--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -9,6 +9,7 @@ import {
   routesNameSeparator,
   STRATEGIES,
   strategy,
+  trailingSlash,
   vuex
 } from './options'
 
@@ -65,8 +66,8 @@ function localeRoute (route, locale) {
         // no prefix for different domains
         !i18n.differentDomains
 
-    const path = (isPrefixed ? `/${locale}${route.path}` : route.path)
-
+    let path = (isPrefixed ? `/${locale}${route.path}` : route.path)
+    path = path.replace(/\/+$/, '') + (trailingSlash ? '/' : '') || '/'
     localizedRoute.path = path
   } else {
     if (!route.name && !route.path) {

--- a/test/fixture/base.config.js
+++ b/test/fixture/base.config.js
@@ -49,12 +49,14 @@ module.exports = {
         fr: {
           home: 'Accueil',
           about: 'À propos',
-          posts: 'Articles'
+          posts: 'Articles',
+          dynamic: 'Dynamique'
         },
         en: {
           home: 'Homepage',
           about: 'About us',
-          posts: 'Posts'
+          posts: 'Posts',
+          dynamic: 'Dynamic'
         }
       },
       fallbackLocale: 'en'

--- a/test/fixture/basic/pages/dynamicNested/index.vue
+++ b/test/fixture/basic/pages/dynamicNested/index.vue
@@ -10,6 +10,11 @@ export default {
     paths: {
       fr: '/imbrication-dynamique'
     }
+  },
+  head () {
+    return {
+      title: this.$t('dynamic')
+    }
   }
 }
 </script>

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -303,7 +303,7 @@ for (const trailingSlash of TRAILING_SLASHES) {
       const window = await nuxt.renderAndGetWindow(url('/'))
       expect(window.$nuxt.localePath('about')).toBe(pathRespectingTrailingSlash('/about-us'))
       expect(window.$nuxt.localePath('about', 'fr')).toBe(pathRespectingTrailingSlash('/fr/a-propos'))
-      expect(window.$nuxt.localePath('/about-us')).toBe('/about-us')
+      expect(window.$nuxt.localePath('/about-us')).toBe(pathRespectingTrailingSlash('/about-us'))
       expect(window.$nuxt.localePath({ path: '/about' })).toBe(pathRespectingTrailingSlash('/about-us'))
       expect(window.$nuxt.localePath({ path: '/about/' })).toBe(pathRespectingTrailingSlash('/about-us'))
     })


### PR DESCRIPTION
Respect "router.trailingSlash" option when using "localePath" with
an absolute path as an argument. The trailing slash is now normalized
according to that option (true: add trailing slash,
false or undefined: remove trailing slash). That excludes the root path
which always includes trailing slash.

An extra fix for #717