### PR TITLE
Change return type of localeRouter from Route to Location

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -57,9 +57,9 @@ In `no_prefix` strategy, passing `locale` other than the current one is not supp
   - **Arguments**:
     - route (type: `string` | [`Location`](https://github.com/vuejs/vue-router/blob/f40139c27a9736efcbda69ec136cb00d8e00fa97/types/router.d.ts#L125))
     - locale (type: `string`, default: current locale)
-  - **Returns**: [`Route`](https://github.com/vuejs/vue-router/blob/f40139c27a9736efcbda69ec136cb00d8e00fa97/types/router.d.ts#L135) | `undefined`
+  - **Returns**: [`Location`](https://github.com/vuejs/vue-router/blob/f40139c27a9736efcbda69ec136cb00d8e00fa97/types/router.d.ts#L125) | `undefined`
 
-  Returns localized route for passed in `route`. If `locale` is not specified, uses current locale.
+  Returns localized location for passed in `route`. If `locale` is not specified, uses current locale.
 
   See also [Basic usage - nuxt-link](../basic-usage.html#nuxt-link).
 

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -2,7 +2,7 @@
 /* eslint-disable no-unused-vars */
 import Vue from 'vue'
 import Vuex from 'vuex'
-import { Route } from 'vue-router'
+import { Location } from 'vue-router'
 import '../index'
 
 const vm = new Vue()
@@ -27,7 +27,10 @@ const routeBaseName: string = vm.getRouteBaseName(vm.$route)
 
 // localeRoute
 
-const localizedRoute: Route | undefined = vm.localeRoute('about', 'fr')
+const localizedRoute: Location | undefined = vm.localeRoute('about', 'fr')
+if (localizedRoute) {
+  vm.$router.push(localizedRoute)
+}
 
 // $i18n
 

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import { RawLocation, Route } from 'vue-router'
+import { Location, RawLocation, Route } from 'vue-router'
 import VueI18n, { IVueI18n } from 'vue-i18n'
 import { NuxtI18nComponentOptions, NuxtVueI18n, NuxtI18nSeo } from './nuxt-i18n'
 
@@ -22,7 +22,7 @@ declare module 'vue-i18n' {
 declare module 'vue/types/vue' {
   interface Vue {
     localePath(route: RawLocation, locale?: string): string
-    localeRoute(route: RawLocation, locale?: string): Route | undefined
+    localeRoute(route: RawLocation, locale?: string): Location | undefined
     switchLocalePath(locale: string): string
     getRouteBaseName(route?: Route): string
     $nuxtI18nSeo(): NuxtI18nSeo


### PR DESCRIPTION
Event though the result is actually a route object, the point of
localeRoute is to return something that can be passed to VueRouter.push()
and that needs to be a Location object.

Location is basically a subset of Route plus some optional properties
so treating Route as Location should be fine.

Resolves #776