### PR TITLE
Fix language detection from route path

### DIFF
--- a/docs/browser-language-detection.md
+++ b/docs/browser-language-detection.md
@@ -16,6 +16,8 @@ By default, **nuxt-i18n** attempts to redirect users to their preferred language
 
 ::: tip
 Browser language is detected either from `navigator` when running on client side, or from the `accept-language` HTTP header. Configured `locales` (or locales `code`s when locales are specified in object form) are matched against locales reported by the browser (for example `en-US,en;q=0.9,no;q=0.8`). If there is no exact match, the language code (letters before `-`) are matched against configured locales (for backwards compatibility).
+
+Keep in mind that for all strategies except `no_prefix` locale might be detected from route path when requested on client side.
 :::
 
 To prevent redirecting users every time they visit the app, **nuxt-i18n** sets a cookie after the first redirection. You can change the cookie's name by setting `detectBrowserLanguage.cookieKey` option to whatever you'd like, the default is _i18n_redirected_.

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -136,7 +136,9 @@ export default async (context) => {
 
     let matchedLocale
 
-    if (useCookie && (matchedLocale = app.i18n.getLocaleCookie())) {
+    if (strategy !== STRATEGIES.NO_PREFIX && (matchedLocale = getLocaleFromRoute(route)) && route.path !== '/') {
+      // Get preferred language from locale route
+    } else if (useCookie && (matchedLocale = app.i18n.getLocaleCookie())) {
       // Get preferred language from cookie if present and enabled
     } else if (process.client && typeof navigator !== 'undefined' && navigator.languages) {
       // Get browser language either from navigator if running on client side, or from the headers
@@ -149,7 +151,13 @@ export default async (context) => {
 
     // Handle cookie option to prevent multiple redirections
     if (finalLocale && (!useCookie || alwaysRedirect || !app.i18n.getLocaleCookie())) {
-      if (finalLocale !== app.i18n.locale) {
+      if (strategy !== STRATEGIES.NO_PREFIX && route.path !== '/') {
+        if (useCookie) {
+          app.i18n.setLocaleCookie(finalLocale)
+        } else {
+          return finalLocale
+        }
+      } else if (finalLocale !== app.i18n.locale) {
         return finalLocale
       } else if (useCookie && !app.i18n.getLocaleCookie()) {
         app.i18n.setLocaleCookie(finalLocale)

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -716,6 +716,17 @@ describe('prefix_and_default strategy', () => {
     const links = dom.querySelectorAll('head link[rel="canonical"]')
     expect(links.length).toBe(0)
   })
+
+  test('default locale from locale path with en locale cookie', async () => {
+    const requestOptions = {
+      headers: {
+        Cookie: 'i18n_redirected=en'
+      }
+    }
+    const html = await get('/fr', requestOptions)
+    const dom = getDom(html)
+    expect(dom.querySelector('#current-locale').textContent).toBe('locale: fr')
+  })
 })
 
 describe('no_prefix strategy', () => {


### PR DESCRIPTION
Fix language detection from route path on all strategies except no_prefix

Not happy with this code block but somehow we need to change the cookie as well.

```
if (strategy !== STRATEGIES.NO_PREFIX && route.path !== '/') {
	if (useCookie) {
	  app.i18n.setLocaleCookie(finalLocale)
	} else {
	  return finalLocale
	}
}
```

@rchl what do you think?

Thanks!